### PR TITLE
explicitly include cmath

### DIFF
--- a/src/touchegg/gestures/factory/GestureFactory.cpp
+++ b/src/touchegg/gestures/factory/GestureFactory.cpp
@@ -18,6 +18,8 @@
  * @author José Expósito <jose.exposito89@gmail.com> (C) 2011 - 2012
  * @class  GestureFactory
  */
+
+#include "cmath"
 #include "GestureFactory.h"
 
 // ****************************************************************************************************************** //

--- a/src/touchegg/gestures/factory/GestureFactory.cpp
+++ b/src/touchegg/gestures/factory/GestureFactory.cpp
@@ -19,7 +19,7 @@
  * @class  GestureFactory
  */
 
-#include "cmath"
+#include <cmath>
 #include "GestureFactory.h"
 
 // ****************************************************************************************************************** //


### PR DESCRIPTION
This fixes a compilation issue with gcc 6.x:

error: call of overloaded ‘abs(float&)’ is ambiguous