### PR TITLE
Allow matching on WM_CLASS name

### DIFF
--- a/src/touchegg/config/Config.cpp
+++ b/src/touchegg/config/Config.cpp
@@ -131,6 +131,22 @@ void Config::initConfig(QFile &file)
      *
      *     </application>
      *
+     *     <application name="windowname.Leela090.exe">
+     *
+     *         <gesture type="TAP" fingers="3" direction="">
+     *             <action type="SEND_KEYS">Alt+P</action>
+     *         </gesture>
+     *
+     *         <gesture type="DRAG" fingers="3" direction="UP">
+     *             <action type="SEND_KEYS">Control+R</action>
+     *         </gesture>
+     *
+     *         <gesture type="DRAG" fingers="3" direction="DOWN">
+     *             <action type="SEND_KEYS">Alt+R</action>
+     *         </gesture>
+     *
+     *     </application>
+     *
      * </touchégg>
      */
 
@@ -265,34 +281,41 @@ int Config::getComposedGesturesTime() const
 
 //------------------------------------------------------------------------------
 
-ActionTypeEnum::ActionType Config::getAssociatedAction(const QString &appClass,
+ActionTypeEnum::ActionType Config::getAssociatedAction(const QString &appName, const QString &appClass,
         GestureTypeEnum::GestureType gestureType, int numFingers,
         GestureDirectionEnum::GestureDirection dir) const
 {
     return ActionTypeEnum::getEnum(getAssociation(
-        appClass, gestureType, numFingers, dir,
+        appName, appClass, gestureType, numFingers, dir,
         "action", ActionTypeEnum::getValue(ActionTypeEnum::NO_ACTION)));
 }
 
-QString Config::getAssociatedSettings(const QString &appClass,
+QString Config::getAssociatedSettings(const QString &appName, const QString &appClass,
         GestureTypeEnum::GestureType gestureType, int numFingers,
         GestureDirectionEnum::GestureDirection dir) const
 {
-    return getAssociation(appClass, gestureType, numFingers, dir, "settings", "");
+    return getAssociation(appName, appClass, gestureType, numFingers, dir, "settings", "");
 }
 
-QString Config::getAssociatedTiming(const QString &appClass,
+QString Config::getAssociatedTiming(const QString &appName, const QString &appClass,
         GestureTypeEnum::GestureType gestureType, int numFingers,
         GestureDirectionEnum::GestureDirection dir) const
 {
-    return getAssociation(appClass, gestureType, numFingers, dir, "timing", "AT_END");
+    return getAssociation(appName, appClass, gestureType, numFingers, dir, "timing", "AT_END");
 }
 
-QString Config::getAssociation(const QString &appClass,
+QString Config::getAssociation(const QString &appName, const QString &appClass,
         GestureTypeEnum::GestureType gestureType, int numFingers,
         GestureDirectionEnum::GestureDirection dir,
         QString settingType, QString defaultValue) const
 {
+    QString exactNameKey = "windowname." + appName + "."
+            + GestureTypeEnum::getValue(gestureType) + "."
+            + QString::number(numFingers) + "."
+            + GestureDirectionEnum::getValue(dir) + "." + settingType;
+    QString allDirectionsNameKey = "windowname." + appName + "."
+            + GestureTypeEnum::getValue(gestureType) + "."
+            + QString::number(numFingers) + ".ALL." + settingType;
     QString exactKey = appClass + "."
             + GestureTypeEnum::getValue(gestureType) + "."
             + QString::number(numFingers) + "."
@@ -308,7 +331,11 @@ QString Config::getAssociation(const QString &appClass,
             + GestureTypeEnum::getValue(gestureType) + "."
             + QString::number(numFingers) + ".ALL." + settingType;
 
-    if (this->settings.contains(exactKey))
+    if (this->settings.contains(exactNameKey))
+        return this->settings.value(exactNameKey);
+    else if (this->settings.contains(allDirectionsNameKey))
+        return this->settings.value(allDirectionsNameKey);
+    else if (this->settings.contains(exactKey))
         return this->settings.value(exactKey);
     else if (this->settings.contains(allDirectionsKey))
         return this->settings.value(allDirectionsKey);

--- a/src/touchegg/config/Config.cpp
+++ b/src/touchegg/config/Config.cpp
@@ -269,84 +269,44 @@ ActionTypeEnum::ActionType Config::getAssociatedAction(const QString &appClass,
         GestureTypeEnum::GestureType gestureType, int numFingers,
         GestureDirectionEnum::GestureDirection dir) const
 {
-    QString exactKey = appClass + "."
-            + GestureTypeEnum::getValue(gestureType) + "."
-            + QString::number(numFingers) + "."
-            + GestureDirectionEnum::getValue(dir) + ".action";
-    QString allDirectionsKey = appClass + "."
-            + GestureTypeEnum::getValue(gestureType) + "."
-            + QString::number(numFingers) + ".ALL.action";
-    QString globalExactKey = "All."
-            + GestureTypeEnum::getValue(gestureType) + "."
-            + QString::number(numFingers) + "."
-            + GestureDirectionEnum::getValue(dir) + ".action";
-    QString globalAllDirectionsKey = "All."
-            + GestureTypeEnum::getValue(gestureType) + "."
-            + QString::number(numFingers) + ".ALL.action";
-
-    if (this->settings.contains(exactKey))
-        return ActionTypeEnum::getEnum(this->settings.value(exactKey));
-    else if (this->settings.contains(allDirectionsKey))
-        return ActionTypeEnum::getEnum(this->settings.value(allDirectionsKey));
-    else if (this->settings.contains(globalExactKey))
-        return ActionTypeEnum::getEnum(this->settings.value(globalExactKey));
-    else if (this->settings.contains(globalAllDirectionsKey))
-        return ActionTypeEnum::getEnum(this->settings.value(
-                globalAllDirectionsKey));
-    else
-        return ActionTypeEnum::NO_ACTION;
+    return ActionTypeEnum::getEnum(getAssociation(
+        appClass, gestureType, numFingers, dir,
+        "action", ActionTypeEnum::getValue(ActionTypeEnum::NO_ACTION)));
 }
 
 QString Config::getAssociatedSettings(const QString &appClass,
         GestureTypeEnum::GestureType gestureType, int numFingers,
         GestureDirectionEnum::GestureDirection dir) const
 {
-    QString exactKey = appClass + "."
-            + GestureTypeEnum::getValue(gestureType) + "."
-            + QString::number(numFingers) + "."
-            + GestureDirectionEnum::getValue(dir) + ".settings";
-    QString allDirectionsKey = appClass + "."
-            + GestureTypeEnum::getValue(gestureType) + "."
-            + QString::number(numFingers) + ".ALL.settings";
-    QString globalExactKey = "All."
-            + GestureTypeEnum::getValue(gestureType) + "."
-            + QString::number(numFingers) + "."
-            + GestureDirectionEnum::getValue(dir) + ".settings";
-    QString globalAllDirectionsKey = "All."
-            + GestureTypeEnum::getValue(gestureType) + "."
-            + QString::number(numFingers) + ".ALL.settings";
-
-    if (this->settings.contains(exactKey))
-        return this->settings.value(exactKey);
-    else if (this->settings.contains(allDirectionsKey))
-        return this->settings.value(allDirectionsKey);
-    else if (this->settings.contains(globalExactKey))
-        return this->settings.value(globalExactKey);
-    else if (this->settings.contains(globalAllDirectionsKey))
-        return this->settings.value(globalAllDirectionsKey);
-    else
-        return "";
+    return getAssociation(appClass, gestureType, numFingers, dir, "settings", "");
 }
-
 
 QString Config::getAssociatedTiming(const QString &appClass,
         GestureTypeEnum::GestureType gestureType, int numFingers,
         GestureDirectionEnum::GestureDirection dir) const
 {
+    return getAssociation(appClass, gestureType, numFingers, dir, "timing", "AT_END");
+}
+
+QString Config::getAssociation(const QString &appClass,
+        GestureTypeEnum::GestureType gestureType, int numFingers,
+        GestureDirectionEnum::GestureDirection dir,
+        QString settingType, QString defaultValue) const
+{
     QString exactKey = appClass + "."
             + GestureTypeEnum::getValue(gestureType) + "."
             + QString::number(numFingers) + "."
-            + GestureDirectionEnum::getValue(dir) + ".timing";
+            + GestureDirectionEnum::getValue(dir) + "." + settingType;
     QString allDirectionsKey = appClass + "."
             + GestureTypeEnum::getValue(gestureType) + "."
-            + QString::number(numFingers) + ".ALL.timing";
+            + QString::number(numFingers) + ".ALL." + settingType;
     QString globalExactKey = "All."
             + GestureTypeEnum::getValue(gestureType) + "."
             + QString::number(numFingers) + "."
-            + GestureDirectionEnum::getValue(dir) + ".timing";
+            + GestureDirectionEnum::getValue(dir) + "." + settingType;
     QString globalAllDirectionsKey = "All."
             + GestureTypeEnum::getValue(gestureType) + "."
-            + QString::number(numFingers) + ".ALL.timing";
+            + QString::number(numFingers) + ".ALL." + settingType;
 
     if (this->settings.contains(exactKey))
         return this->settings.value(exactKey);
@@ -357,5 +317,5 @@ QString Config::getAssociatedTiming(const QString &appClass,
     else if (this->settings.contains(globalAllDirectionsKey))
         return this->settings.value(globalAllDirectionsKey);
     else
-        return "AT_END";
+        return defaultValue;
 }

--- a/src/touchegg/config/Config.h
+++ b/src/touchegg/config/Config.h
@@ -68,38 +68,44 @@ public:
 
     /**
      * Returns the associated action type with a gesture.
-     * @param  appClass Application where it is made ​​the gesture.
+     * @param  appName Application name where the gesture happened.
+     * @param  appClass Application class where ​​the gesture happened.
      * @param  gestureType The gesture that is made.
      * @param  numFingers Number of fingers used by the gesture.
      * @param  dir Direction of the gesture.
      * @return Type of associated action.
      */
-    ActionTypeEnum::ActionType getAssociatedAction(const QString &appClass,
+    ActionTypeEnum::ActionType getAssociatedAction(
+            const QString &appName, const QString &appClass,
             GestureTypeEnum::GestureType gestureType, int numFingers,
             GestureDirectionEnum::GestureDirection dir) const;
 
     /**
      * Returns the associated config with the indicated gesture.
-     * @param  appClass Application where it is made ​​the gesture.
+     * @param  appName Application name where the gesture happened.
+     * @param  appClass Application class where ​​the gesture happened.
      * @param  gestureType The gesture that is made.
      * @param  numFingers Number of fingers used by the gesture.
      * @param  dir Direction of the gesture.
      * @return The settings.
      */
-    QString getAssociatedSettings(const QString &appClass,
+    QString getAssociatedSettings(
+            const QString &appName, const QString &appClass,
             GestureTypeEnum::GestureType gestureType, int numFingers,
             GestureDirectionEnum::GestureDirection dir) const;
 
     /**
      * Returns the associated timing information for the action 
      * with the indicated gesture.
-     * @param  appClass Application where it is made ​​the gesture.
+     * @param  appName Application name where the gesture happened.
+     * @param  appClass Application class where ​​the gesture happened.
      * @param  gestureType The gesture that is made.
      * @param  numFingers Number of fingers used by the gesture.
      * @param  dir Direction of the gesture.
      * @return The timing information, either "AT_START" or "AT_END".
      */
-    QString getAssociatedTiming(const QString &appClass,
+    QString getAssociatedTiming(
+            const QString &appName, const QString &appClass,
             GestureTypeEnum::GestureType gestureType, int numFingers,
             GestureDirectionEnum::GestureDirection dir) const;
 
@@ -109,7 +115,8 @@ private:
     /**
      * Returns the associated setting for the indicated gesture.
      * `settingType` can be one of "action", "setting", or "timing".
-     * @param  appClass Application where it is made ​​the gesture.
+     * @param  appName Application name where the gesture happened.
+     * @param  appClass Application class where ​​the gesture happened.
      * @param  gestureType The gesture that is made.
      * @param  numFingers Number of fingers used by the gesture.
      * @param  dir Direction of the gesture.
@@ -117,10 +124,11 @@ private:
      * @param  defaultValue Value to return if the setting does not exist.
      * @return The specified setting or the default value if does not exist.
      */
-    QString getAssociation(const QString &appClass,
-        GestureTypeEnum::GestureType gestureType, int numFingers,
-        GestureDirectionEnum::GestureDirection dir,
-        QString settingType, QString defaultValue) const;
+    QString getAssociation(
+            const QString &appName, const QString &appClass,
+            GestureTypeEnum::GestureType gestureType, int numFingers,
+            GestureDirectionEnum::GestureDirection dir,
+            QString settingType, QString defaultValue) const;
 
     /**
      * Initializes the QHash's for the configuration and used gestures.

--- a/src/touchegg/config/Config.h
+++ b/src/touchegg/config/Config.h
@@ -107,6 +107,22 @@ public:
 private:
 
     /**
+     * Returns the associated setting for the indicated gesture.
+     * `settingType` can be one of "action", "setting", or "timing".
+     * @param  appClass Application where it is made ​​the gesture.
+     * @param  gestureType The gesture that is made.
+     * @param  numFingers Number of fingers used by the gesture.
+     * @param  dir Direction of the gesture.
+     * @param  settingType Type of setting to retrieve.
+     * @param  defaultValue Value to return if the setting does not exist.
+     * @return The specified setting or the default value if does not exist.
+     */
+    QString getAssociation(const QString &appClass,
+        GestureTypeEnum::GestureType gestureType, int numFingers,
+        GestureDirectionEnum::GestureDirection dir,
+        QString settingType, QString defaultValue) const;
+
+    /**
      * Initializes the QHash's for the configuration and used gestures.
      * @param file File from which to read configuration.
      * @see settings

--- a/src/touchegg/gestures/handler/GestureHandler.h
+++ b/src/touchegg/gestures/handler/GestureHandler.h
@@ -72,6 +72,10 @@ private slots:
 
 private:
 
+    struct WindowClassHint {
+      QString windowName, windowClass;
+    };
+
     /**
      * Create a estandar gesture with their action.
      * @param  type  Gesture type.
@@ -103,11 +107,13 @@ private:
     Window getTopLevelWindow(Window window) const;
 
     /**
-     * Returns the class of a window, for example, "XTerm" is the class of all instances of XTerm.
+     * Returns the name and the class of a window.  For example,
+     * "xterm" is the name and "XTerm" is the class of all instances
+     * of XTerm.
      * @param  window This window.
-     * @return The class.
+     * @return The name and class of the window.
      */
-    QString getAppClass(Window window) const;
+    WindowClassHint getAppClass(Window window) const;
 
     //------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
The X class hint contains two values: The name and the class.  For certain applications such as wine, matching on the class is not useful because it is too generic.  For cases like this, matching on the name is needed.

This commit is an easy fix to match on window names; by specifying an application name like "windowname.Foo" in the config file, this will match all windows named "Foo".

This is the WM_CLASS name property (which is usually static) and not the WM_NAME property (which often changes during the run of a program).