### PR TITLE
Fix some typos in English comments and documentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@
    applications that uses their own gestures
  - Touchégg ported to GEIS v2 API
  - Touchégg now uses a XML configuration file more intuitive, easy and cleaned
-   and some action configurations has been enchancement.
+   and some action configurations have been enhanced.
  - The code is adapted to the Qt/KDE coding style
  
  Added support for the following actions:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 About Touchégg:
 ===============
 
-Touchégg allows the GNU/Linux users to made full use of their trackpacks.
+Touchégg allows the GNU/Linux users to make full use of their trackpacks.
 
-By editing a simple configuration file you can attach an action to a particular gesture and -by performing those gestures on your trackpad- maximize, minimize or resize windows, show your desktop, emulate mouse clicks and more.
+By editing a simple configuration file you can attach an action to a particular gesture and – by performing those gestures on your trackpad – maximize, minimize or resize windows, show your desktop, emulate mouse clicks and more.
 
 <p align="center">
   <a href="https://www.youtube.com/watch?v=1Ek4QaFQ1qo">

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ About Touchégg:
 
 Touchégg allows the GNU/Linux users to make full use of their trackpacks.
 
-By editing a simple configuration file you can attach an action to a particular gesture and – by performing those gestures on your trackpad – maximize, minimize or resize windows, show your desktop, emulate mouse clicks and more.
+By editing a simple configuration file you can attach an action to a particular gesture and –by performing those gestures on your trackpad– maximize, minimize or resize windows, show your desktop, emulate mouse clicks and more.
 
 <p align="center">
   <a href="https://www.youtube.com/watch?v=1Ek4QaFQ1qo">

--- a/src/touchegg/Touchegg.h
+++ b/src/touchegg/Touchegg.h
@@ -27,8 +27,8 @@
 #include "src/touchegg/gestures/handler/GestureHandler.h"
 
 /**
- * Initializes and launches Touchégg. To do this uses this three clases:
- * - WindowListener: To detect the creation or destruction of the windows and listen, if is neccessary, the multitouch
+ * Initializes and launches Touchégg. To do this uses these three classes:
+ * - WindowListener: To detect the creation or destruction of the windows and listen, if is necessary, the multitouch
  *   events in that window.
  * - GestureCollector: To get the multitouch events in the windows selected by the WindowListener.
  * - GestureHandler: To treat the multitouch events collected by the GestureCollector.
@@ -48,7 +48,7 @@ protected:
 
     /**
      * Reimplement the method QApplication::x11EventFilter. This method receives the notifications of
-     * creation/destruction of windows and manage it as appropiate using WindowListener.
+     * creation/destruction of windows and manage it as appropriate using WindowListener.
      * @param  event The event that occurred.
      * @return true if you want to stop the event from being processed, ie when we treat ourselves, false for normal
      *         event dispatching.

--- a/src/touchegg/gestures/collector/GestureCollector.h
+++ b/src/touchegg/gestures/collector/GestureCollector.h
@@ -83,7 +83,7 @@ public slots:
 signals:
 
     /**
-     * Signal emited when uTouch is inicializzed.
+     * Signal emitted when uTouch is initialized.
      */
     void ready();
 

--- a/src/touchegg/gestures/handler/GestureHandler.cpp
+++ b/src/touchegg/gestures/handler/GestureHandler.cpp
@@ -86,7 +86,7 @@ void GestureHandler::executeGestureUpdate(const QString &type, int id, const QHa
             }
         }
 
-    // If is an update whith the timer running it is a DOUBLE_TAP or a TAP_AND_HOLD
+    // If is an update with the timer running it is a DOUBLE_TAP or a TAP_AND_HOLD
     } else if (this->currentGesture != NULL && this->timerTap->isActive()) {
         this->timerTap->stop();
 

--- a/src/touchegg/windows/WindowListener.h
+++ b/src/touchegg/windows/WindowListener.h
@@ -55,12 +55,12 @@ public:
 signals:
 
     /**
-     * Emited when a new window is created.
+     * Emitted when a new window is created.
      */
     void windowCreated(Window w);
 
     /**
-     * Emited when a window is closed/deleted.
+     * Emitted when a window is closed/deleted.
      */
     void windowDeleted(Window w);
 


### PR DESCRIPTION
Some of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>