### PR TITLE
debian: Use the modern dbgsym package instead of the handmade -dbg one

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,13 +26,3 @@ Description: Multi-touch gesture recognizer
  into visible actions in your desktop.
  For example, you can swipe up with 3 fingers to maximize a window or swipe left with 4 finger to
  switch to the next desktop.
-
-Package: touchegg-dbg
-Section: debug
-Architecture: any
-Priority: extra
-Depends: touchegg (= ${binary:Version}), ${misc:Depends}
-Description: Debugging symbols for Touchégg
- This package contains debugging files used to investigate problems with
- Touchégg. Install this package if you are experiencing crashes of the
- Touchégg application and wish to report a problem to the developers.

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,4 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --dbg-package=touchegg-dbg --with=systemd
+	dh $@ --with=systemd

--- a/debian/touchegg.install
+++ b/debian/touchegg.install
@@ -1,4 +1,0 @@
-usr/bin/*
-usr/share/*
-lib/systemd/system/*
-etc/xdg/autostart/*


### PR DESCRIPTION
This also allows us to remove the .install files as there is only one package.