### PR TITLE
Add support for building snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,86 @@
+name: touchegg
+base: core18
+adopt-info: touchegg
+summary: Touchégg
+description: |
+  Touchégg is an app that runs in the background and transform
+  the gestures you make on your touchpad into visible actions
+  in your desktop.
+
+grade: stable
+confinement: strict
+
+parts:
+  touchegg:
+    plugin: cmake
+    source: .
+    # cmake-parameters: ["-DCMAKE_BUILD_TYPE=Release"] # if using core20
+    configflags: ["-DCMAKE_BUILD_TYPE=Release"] # if using core18
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags)"
+    build-packages:
+      - build-essential
+      - gdb
+      - cmake
+      - debhelper
+      - libudev-dev
+      - libinput-dev
+      - libpugixml-dev
+      - libcairo2-dev
+      - libx11-dev
+      - libxtst-dev
+      - libxrandr-dev
+      - libxi-dev
+      - libgtk-3-dev
+    stage-packages: # if not using the GNOME extension
+      - libatk-bridge2.0-0                                                                                                                                                                     
+      - libatk1.0-0                                                                                                                                                                            
+      - libatspi2.0-0                                                                             
+      - libcairo-gobject2                                                                         
+      - libcairo2                                                                                 
+      - libdatrie1                                                                                
+      - libepoxy0                                                                                 
+      - libevdev2                                                                                                                                                                              
+      - libfontconfig1                                                                            
+      - libfreetype6                        
+      - libgdk-pixbuf2.0-0        
+      - libgraphite2-3                
+      - libgtk-3-0                
+      - libgudev-1.0-0      
+      - libharfbuzz0b                    
+      - libinput10                                                                                
+      - libmtdev1                                                                                 
+      - libpango-1.0-0                                                                            
+      - libpangocairo-1.0-0                                                                       
+      - libpangoft2-1.0-0 
+      - libpixman-1-0  
+      - libpng16-16                                                                                                                                                                            
+      - libpugixml1v5
+      - libthai0          
+      - libwacom2    
+      - libwayland-client0
+      - libwayland-cursor0
+      - libwayland-egl1
+      - libx11-6                                                                                                                                                                               
+      - libxau6                                   
+      - libxcb-render0
+      - libxcb-shm0                                             
+      - libxcb1                                                 
+      - libxcomposite1                                          
+      - libxcursor1                                             
+      - libxdamage1                                             
+      - libxdmcp6                                               
+      - libxext6                                                
+      - libxfixes3                                                                                                                                                                                                                            
+      - libxi6                                                  
+      - libxinerama1                                            
+      - libxkbcommon0                                                   
+      - libxrandr2                                                      
+      - libxrender1                                                     
+      - libxtst6 
+apps:
+  touchegg:
+    daemon: simple
+    #extensions: [gnome-3-34] # causes build failures in harfbuzz
+    command: usr/bin/touchegg


### PR DESCRIPTION
Attempt to build a snap of touchegg. Not currently working.

### To build, on Ubuntu, locally:

Setup:
```
snap install snapcraft
snap install lxd
sudo lxd init --auto
```
Clone this repo, then from within it:
`snapcraft --use-lxd`

### To build remotely in the :cloud: 
(requires launchpad.net account)
`snap install snapcraft`
Clone this repo then from within it:
`snapcraft remote-build`

### Install the snap:
`snap install touchegg_2.0.3-6-*_amd64.snap --dangerous`

To check logs:
```
snap logs touchegg
```

Current issue:
```
$ snap logs touchegg 
2020-11-19T09:55:18Z touchegg.touchegg[1984594]: terminate called after throwing an instance of 'std::runtime_error'
2020-11-19T09:55:18Z touchegg.touchegg[1984594]:   what():  File /usr/share/touchegg/touchegg.conf not found.
2020-11-19T09:55:18Z touchegg.touchegg[1984594]: Reinstall Touchégg to solve this issue
2020-11-19T09:55:19Z systemd[1]: snap.touchegg.touchegg.service: Main process exited, code=dumped, status=6/ABRT
2020-11-19T09:55:19Z systemd[1]: snap.touchegg.touchegg.service: Failed with result 'core-dump'.
2020-11-19T09:55:19Z systemd[1]: snap.touchegg.touchegg.service: Scheduled restart job, restart counter is at 5.
2020-11-19T09:55:19Z systemd[1]: Stopped Service for snap application touchegg.touchegg.
2020-11-19T09:55:19Z systemd[1]: snap.touchegg.touchegg.service: Start request repeated too quickly.
2020-11-19T09:55:19Z systemd[1]: snap.touchegg.touchegg.service: Failed with result 'core-dump'.
2020-11-19T09:55:19Z systemd[1]: Failed to start Service for snap application touchegg.touchegg.
```

Other issues:
It would be nice to use the `gnome-3-34` extension rather than bundle all the `stage-packages` but when I built with the extension (and omitted the entire `stage-packages` stanza) it fails to build with:

```
[ 94%] Building CXX object CMakeFiles/touchegg.dir/src/window-system/x11-cairo-surface.cpp.o                                                                                                                                                                             
[ 97%] Building CXX object CMakeFiles/touchegg.dir/src/window-system/x11.cpp.o                                                                                                                                                                                           
[100%] Linking CXX executable touchegg                                                                                                                                                                                                                                   
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0: undefined reference to `hb_ot_layout_script_select_language'                                                                                                                            
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0: undefined reference to `pango_font_get_hb_font'                                                                                                                                         
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0: undefined reference to `pango_font_description_set_variations'                                                                                                                          
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0: undefined reference to `hb_blob_create_from_file'                                                                                                                                       
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0: undefined reference to `atk_text_scroll_substring_to'                                                                                                                                 
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0: undefined reference to `hb_ot_var_named_instance_get_design_coords'                                                                                                                     
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0: undefined reference to `pango_coverage_get_type'                                                                                                                                        
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0: undefined reference to `pango_font_description_get_variations'                                                                                                                          
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0: undefined reference to `atk_component_scroll_to'                                                                                                                                      
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0: undefined reference to `hb_ot_tags_from_script_and_language'                                                                                                                            
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0: undefined reference to `atk_component_scroll_to_point'                                                                                                                                
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0: undefined reference to `atk_object_get_accessible_id'                                                                                                                                 
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0: undefined reference to `hb_ot_var_get_axis_infos'                                                                                                                                       
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0: undefined reference to `atk_text_scroll_substring_to_point'                                                                                                                           
/snap/gnome-3-34-1804-sdk/current/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0: undefined reference to `hb_ot_metrics_get_position'                                                                                                                                     
collect2: error: ld returned 1 exit status                                                                                                                                                                                                                               
CMakeFiles/touchegg.dir/build.make:1004: recipe for target 'touchegg' failed                                                                                                                                                                                             
make[2]: *** [touchegg] Error 1                                                                                                                                                                                                                                          
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/touchegg.dir/all' failed                                                                                                                                                                                          
make[1]: *** [CMakeFiles/touchegg.dir/all] Error 2                                                                                                                                                                                                                       
Makefile:151: recipe for target 'all' failed                                                                                                                                                                                                                             
make: *** [all] Error 2    
```

