### PR TITLE
Fix #419 for send-keys and run-command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ obj-*-linux-gnu/
 Thumbs.db
 ehthumbs.db
 Desktop.ini
+
+# ctags
+.cpptags

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Find more information in the sections below.
 | Option | Value | Default | Description | Example
 | - | - | - | - | - |
 | animation_delay | Number | 150 | Delay, in milliseconds, since the gesture starts before the animation is displayed | Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that no animation is displayed if you complete the action quick enough. This property configures that time |
-| action_execute_threshold | Number | 20 | Percentage of the animation to be completed to apply the action | Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that, even if the animation is displayed, the action is not executed if you did not moved your fingers far enough. This property configures the percentage of the animation that must be reached to execute the action |
+| action_execute_threshold | Number | 20 | Percentage of the gesture to be completed to apply the action | Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that, even if the animation is displayed, the action is not executed if you did not move your fingers far enough. This property configures the percentage of the gesture that must be reached to execute the action |
 | color | Hex color | 3E9FED | Color of the animation | `#909090`
 | borderColor | Hex color | 3E9FED | Color of the animation | `FFFFFF`
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Find more information in the sections below.
 | Option | Value | Default | Description | Example
 | - | - | - | - | - |
 | animation_delay | Number | 150 | Delay, in milliseconds, since the gesture starts before the animation is displayed | Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that no animation is displayed if you complete the action quick enough. This property configures that time |
-| action_execute_threshold | Number | 20 | Percentage of the gesture to be completed to apply the action | Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that, even if the animation is displayed, the action is not executed if you did not move your fingers far enough. This property configures the percentage of the gesture that must be reached to execute the action |
+| action_execute_threshold | Number | 20 | Percentage of the gesture to be completed to apply the action. Set to 0 to execute actions unconditionally, and to 101 to never execute any actions | Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that, even if the animation is displayed, the action is not executed if you did not move your fingers far enough. This property configures the percentage of the gesture that must be reached to execute the action |
 | color | Hex color | 3E9FED | Color of the animation | `#909090`
 | borderColor | Hex color | 3E9FED | Color of the animation | `FFFFFF`
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Find more information in the sections below.
 | Option | Value | Default | Description | Example
 | - | - | - | - | - |
 | animation_delay | Number | 150 | Delay, in milliseconds, since the gesture starts before the animation is displayed | Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that no animation is displayed if you complete the action quick enough. This property configures that time |
-| action_execute_threshold | Number | 20 | Percentage of the gesture to be completed to apply the action. Set to 0 to execute actions unconditionally, and to 101 to never execute any actions | Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that, even if the animation is displayed, the action is not executed if you did not move your fingers far enough. This property configures the percentage of the gesture that must be reached to execute the action |
+| action_execute_threshold | Number | 20 | Percentage of the gesture to be completed to apply the action. Set to 0 to execute actions unconditionally | Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that, even if the animation is displayed, the action is not executed if you did not move your fingers far enough. This property configures the percentage of the gesture that must be reached to execute the action |
 | color | Hex color | 3E9FED | Color of the animation | `#909090`
 | borderColor | Hex color | 3E9FED | Color of the animation | `FFFFFF`
 

--- a/installation/touchegg.conf
+++ b/installation/touchegg.conf
@@ -10,11 +10,11 @@
     <property name="animation_delay">150</property>
 
     <!--
-      Percentage of the animation to be completed to apply the action.
+      Percentage of the gesture to be completed to apply the action.
       Default: 20% if this property is not set.
       Example: Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that, even if the
-      animation is displayed, the action is not executed if you did not moved your fingers far
-      enough. This property configures the percentage of the animation that must be reached to
+      animation is displayed, the action is not executed if you did not move your fingers far
+      enough. This property configures the percentage of the gesture that must be reached to
       execute the action.
     -->
     <property name="action_execute_threshold">20</property>

--- a/installation/touchegg.conf
+++ b/installation/touchegg.conf
@@ -10,7 +10,7 @@
     <property name="animation_delay">150</property>
 
     <!--
-      Percentage of the gesture to be completed to apply the action.
+      Percentage of the gesture to be completed to apply the action. Set to 0 to execute actions unconditionally, and to 101 to never execute any actions.
       Default: 20% if this property is not set.
       Example: Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that, even if the
       animation is displayed, the action is not executed if you did not move your fingers far

--- a/installation/touchegg.conf
+++ b/installation/touchegg.conf
@@ -10,7 +10,7 @@
     <property name="animation_delay">150</property>
 
     <!--
-      Percentage of the gesture to be completed to apply the action. Set to 0 to execute actions unconditionally, and to 101 to never execute any actions.
+      Percentage of the gesture to be completed to apply the action. Set to 0 to execute actions unconditionally.
       Default: 20% if this property is not set.
       Example: Use the MAXIMIZE_RESTORE_WINDOW action. You will notice that, even if the
       animation is displayed, the action is not executed if you did not move your fingers far

--- a/src/actions/action.cpp
+++ b/src/actions/action.cpp
@@ -1,4 +1,23 @@
+/**
+ * Copyright 2011 - 2020 José Expósito <jose.exposito89@gmail.com>
+ *
+ * This file is part of Touchégg.
+ *
+ * Touchégg is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License  as  published by  the  Free Software
+ * Foundation,  either version 3 of the License,  or (at your option)  any later
+ * version.
+ *
+ * Touchégg is distributed in the hope that it will be useful,  but  WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the  GNU General Public License  for more details.
+ *
+ * You should have received a copy of the  GNU General Public License along with
+ * Touchégg. If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "actions/action.h"
+
+#include <algorithm>
 
 int Action::readThreshold(const Config &config) {
   int threshold = 0;

--- a/src/actions/action.cpp
+++ b/src/actions/action.cpp
@@ -30,5 +30,5 @@ int Action::readThreshold(const Config &config) {
     // leave default 0 if numeric conversion failed
   }
   // discard negative percentage
-  return std::max(threshold, 0);
+  return std::clamp(threshold, 0, 100);
 }

--- a/src/actions/action.cpp
+++ b/src/actions/action.cpp
@@ -1,0 +1,15 @@
+#include "actions/action.h"
+
+int Action::readThreshold(const Config &config) {
+  int threshold = 0;
+  try {
+    threshold =
+      std::stoi(config.getGlobalSetting("action_execute_threshold"));
+  } catch (std::exception& e) {
+    std::cout << "Bad action_execute_threshold value: "
+              << e.what() << std::endl;
+    // leave default 0 if numeric conversion failed
+  }
+  // discard negative percentage
+  return std::max(threshold, 0);
+}

--- a/src/actions/action.h
+++ b/src/actions/action.h
@@ -49,7 +49,7 @@ class Action {
         windowSystem(windowSystem),
         window(window),
         config(config),
-        threshold(this->readThreshold(config)) {}
+        threshold(Action::readThreshold(config)) {}
   virtual ~Action() = default;
 
   /**

--- a/src/actions/action.h
+++ b/src/actions/action.h
@@ -31,7 +31,11 @@
  */
 class Action {
  private:
-  /** Failsafe read gesture threshold property from config */
+  /**
+   * Fail-safe read gesture threshold property from config.
+   * @param config Config to read threshold value from
+   * @returns non-negative value of execute_threshold
+   */
   static int readThreshold(const Config &config);
 
  public:
@@ -67,8 +71,10 @@ class Action {
   const WindowSystem &windowSystem;
   const WindowT &window;
   const Config &config;
-  /** Special config value: threshold to execute action. All derived actions
-   * must respect this */
+  /**
+   * Special config value: threshold to execute action. All derived actions
+   * must respect this.
+   */
   const int threshold;
 };
 

--- a/src/actions/action.h
+++ b/src/actions/action.h
@@ -30,6 +30,10 @@
  * Base class for all actions. Use the ActionFactory to build actions.
  */
 class Action {
+ private:
+  /** Failsafe read gesture threshold property from config */
+  static int readThreshold(const Config &config);
+
  public:
   /**
    * Default constructor.
@@ -44,7 +48,8 @@ class Action {
       : settings(std::move(settings)),
         windowSystem(windowSystem),
         window(window),
-        config(config) {}
+        config(config),
+        threshold(this->readThreshold(config)) {}
   virtual ~Action() = default;
 
   /**
@@ -62,6 +67,9 @@ class Action {
   const WindowSystem &windowSystem;
   const WindowT &window;
   const Config &config;
+  /** Special config value: threshold to execute action. All derived actions
+   * must respect this */
+  const int threshold;
 };
 
 #endif  // ACTIONS_ACTION_H_

--- a/src/actions/animated-action.cpp
+++ b/src/actions/animated-action.cpp
@@ -68,7 +68,7 @@ void AnimatedAction::onGestureUpdate(const Gesture &gesture) {
 }
 
 void AnimatedAction::onGestureEnd(const Gesture &gesture) {
-  if (!this->animate || gesture.percentage() > this->threshold) {
+  if (!this->animate || gesture.percentage() >= this->threshold) {
     this->executeAction(gesture);
   }
 }

--- a/src/actions/animated-action.cpp
+++ b/src/actions/animated-action.cpp
@@ -68,10 +68,7 @@ void AnimatedAction::onGestureUpdate(const Gesture &gesture) {
 }
 
 void AnimatedAction::onGestureEnd(const Gesture &gesture) {
-  int threshold =
-      std::stoi(this->config.getGlobalSetting("action_execute_threshold"));
-
-  if (!this->animate || gesture.percentage() >= threshold) {
+  if (!this->animate || gesture.percentage() > this->threshold) {
     this->executeAction(gesture);
   }
 }

--- a/src/actions/repeated-action.cpp
+++ b/src/actions/repeated-action.cpp
@@ -68,7 +68,7 @@ void RepeatedAction::onGestureUpdate(const Gesture &gesture) {
 
 void RepeatedAction::onGestureEnd(const Gesture &gesture) {
   if (!this->repeat && !this->onBegin) {
-    if (gesture.percentage() > this->threshold) {
+    if (gesture.percentage() >= this->threshold) {
       this->executeAction(gesture);
     }
   }

--- a/src/actions/repeated-action.cpp
+++ b/src/actions/repeated-action.cpp
@@ -33,22 +33,13 @@ void RepeatedAction::onGestureBegin(const Gesture &gesture) {
   // execute supplied prelude
   this->executePrelude();
 
-  // run action if required
+  // run action on begin
   if (!this->repeat && this->onBegin) {
-    if (gesture.percentage() > this->threshold) {
-      this->executeAction(gesture);
-      this->onBeginExecuted = true;
-    }
+    this->executeAction(gesture);
   }
 }
 
 void RepeatedAction::onGestureUpdate(const Gesture &gesture) {
-  if (this->onBegin && !this->onBeginExecuted) {
-    if (gesture.percentage() > this->threshold) {
-      this->executeAction(gesture);
-      this->onBeginExecuted = true;
-    }
-  }
   if (this->repeat) {
     constexpr int step = 10;
     bool increased = (gesture.percentage() >= (this->repeatPercentage + step));

--- a/src/actions/repeated-action.cpp
+++ b/src/actions/repeated-action.cpp
@@ -17,13 +17,11 @@
  */
 #include "actions/repeated-action.h"
 
-
 void RepeatedAction::executePrelude() {}
 void RepeatedAction::executePostlude() {}
 
-void RepeatedAction::onGestureBegin(const Gesture &gesture)
-{
-  // read action settings
+void RepeatedAction::onGestureBegin(const Gesture &gesture) {
+  // read repeated action settings
   if (this->settings.count("repeat") == 1) {
     this->repeat = (this->settings.at("repeat") == "true");
   }
@@ -31,8 +29,10 @@ void RepeatedAction::onGestureBegin(const Gesture &gesture)
   if (this->settings.count("on") == 1) {
     this->onBegin = (this->settings.at("on") == "begin");
   }
+
   // execute supplied prelude
   this->executePrelude();
+
   // run action if required
   if (!this->repeat && this->onBegin) {
     if (gesture.percentage() > this->threshold) {
@@ -42,8 +42,7 @@ void RepeatedAction::onGestureBegin(const Gesture &gesture)
   }
 }
 
-void RepeatedAction::onGestureUpdate(const Gesture &gesture)
-{
+void RepeatedAction::onGestureUpdate(const Gesture &gesture) {
   if (this->onBegin && !this->onBeginExecuted) {
     if (gesture.percentage() > this->threshold) {
       this->executeAction(gesture);
@@ -67,8 +66,7 @@ void RepeatedAction::onGestureUpdate(const Gesture &gesture)
   }
 }
 
-void RepeatedAction::onGestureEnd(const Gesture &gesture)
-{
+void RepeatedAction::onGestureEnd(const Gesture &gesture) {
   if (!this->repeat && !this->onBegin) {
     if (gesture.percentage() > this->threshold) {
       this->executeAction(gesture);

--- a/src/actions/repeated-action.cpp
+++ b/src/actions/repeated-action.cpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2011 - 2020 José Expósito <jose.exposito89@gmail.com>
+ *
+ * This file is part of Touchégg.
+ *
+ * Touchégg is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License  as  published by  the  Free Software
+ * Foundation,  either version 3 of the License,  or (at your option)  any later
+ * version.
+ *
+ * Touchégg is distributed in the hope that it will be useful,  but  WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the  GNU General Public License  for more details.
+ *
+ * You should have received a copy of the  GNU General Public License along with
+ * Touchégg. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "actions/repeated-action.h"
+
+
+void RepeatedAction::executePrelude() {}
+void RepeatedAction::executePostlude() {}
+
+void RepeatedAction::onGestureBegin(const Gesture &gesture)
+{
+  // read action settings
+  if (this->settings.count("repeat") == 1) {
+    this->repeat = (this->settings.at("repeat") == "true");
+  }
+
+  if (this->settings.count("on") == 1) {
+    this->onBegin = (this->settings.at("on") == "begin");
+  }
+  // execute supplied prelude
+  this->executePrelude();
+  // run action if required
+  if (!this->repeat && this->onBegin) {
+    if (gesture.percentage() > this->threshold) {
+      this->executeAction(gesture);
+      this->onBeginExecuted = true;
+    }
+  }
+}
+
+void RepeatedAction::onGestureUpdate(const Gesture &gesture)
+{
+  if (this->onBegin && !this->onBeginExecuted) {
+    if (gesture.percentage() > this->threshold) {
+      this->executeAction(gesture);
+      this->onBeginExecuted = true;
+    }
+  }
+  if (this->repeat) {
+    constexpr int step = 10;
+    bool increased = (gesture.percentage() >= (this->repeatPercentage + step));
+    bool decreased = (gesture.percentage() <= (this->repeatPercentage - step));
+
+    if (increased) {
+      this->executeAction(gesture);
+      this->repeatPercentage += step;
+    }
+
+    if (decreased) {
+      this->executeReverse(gesture);
+      this->repeatPercentage -= step;
+    }
+  }
+}
+
+void RepeatedAction::onGestureEnd(const Gesture &gesture)
+{
+  if (!this->repeat && !this->onBegin) {
+    if (gesture.percentage() > this->threshold) {
+      this->executeAction(gesture);
+    }
+  }
+
+  this->executePostlude();
+}

--- a/src/actions/repeated-action.h
+++ b/src/actions/repeated-action.h
@@ -50,10 +50,12 @@ class RepeatedAction : public Action {
   virtual void executePostlude();
   /**
    * Override this method to configure what is executed for succesful gesture
+   * @param gesture The gesture that triggered the action
    */
   virtual void executeAction(const Gesture &gesture) = 0;
   /**
    * Override this method to configure what is executed for reversed gesture
+   * @param gesture The gesture that triggered the action
    */
   virtual void executeReverse(const Gesture &gesture) = 0;
 
@@ -61,8 +63,10 @@ class RepeatedAction : public Action {
   bool repeat = false;
   int repeatPercentage = 0;
   bool onBegin = true;
-  /** Safeguard against executing onBegin action multiple times when execution
-   * threshold is surpassed multiple times */
+  /**
+   * Safeguard against executing onBegin action multiple times when execution
+   * threshold is surpassed multiple times
+   */
   bool onBeginExecuted = false;
 };
 

--- a/src/actions/repeated-action.h
+++ b/src/actions/repeated-action.h
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2011 - 2020 José Expósito <jose.exposito89@gmail.com>
+ *
+ * This file is part of Touchégg.
+ *
+ * Touchégg is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License  as  published by  the  Free Software
+ * Foundation,  either version 3 of the License,  or (at your option)  any later
+ * version.
+ *
+ * Touchégg is distributed in the hope that it will be useful,  but  WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the  GNU General Public License  for more details.
+ *
+ * You should have received a copy of the  GNU General Public License along with
+ * Touchégg. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef ACTIONS_REPEATED_ACTION_H_
+#define ACTIONS_REPEATED_ACTION_H_
+
+#include "actions/action.h"
+
+class RepeatedAction : public Action {
+ public:
+  using Action::Action;
+  virtual ~RepeatedAction() = default;
+
+  /**
+   * Execute gesture on begin if threshold passed
+   */
+  void onGestureBegin(const Gesture &gesture) override;
+  /**
+   * Execute gesture repeatedly
+   */
+  void onGestureUpdate(const Gesture &gesture) override;
+  /**
+   * Execute gesture on end if threshold passed
+   */
+  void onGestureEnd(const Gesture &gesture) override;
+
+  /**
+   * If your action requires some pre-setup, override this method. This is
+   * executed unconditionally upon gesture beginning
+   */
+  virtual void executePrelude();
+  /**
+   * If your action requires some post-setup, override this method. This is
+   * executed unconditionally upon gesture ending
+   */
+  virtual void executePostlude();
+  /**
+   * Override this method to configure what is executed for succesful gesture
+   */
+  virtual void executeAction(const Gesture &gesture) = 0;
+  /**
+   * Override this method to configure what is executed for reversed gesture
+   */
+  virtual void executeReverse(const Gesture &gesture) = 0;
+
+ protected:
+  bool repeat = false;
+  int repeatPercentage = 0;
+  bool onBegin = true;
+  /** Safeguard against executing onBegin action multiple times when execution
+   * threshold is surpassed multiple times */
+  bool onBeginExecuted = false;
+};
+
+
+#endif  // ACTIONS_REPEATED_ACTION_H_

--- a/src/actions/repeated-action.h
+++ b/src/actions/repeated-action.h
@@ -26,7 +26,7 @@ class RepeatedAction : public Action {
   virtual ~RepeatedAction() = default;
 
   /**
-   * Execute gesture on begin if threshold passed
+   * Execute gesture on begin
    */
   void onGestureBegin(const Gesture &gesture) override;
   /**
@@ -63,11 +63,6 @@ class RepeatedAction : public Action {
   bool repeat = false;
   int repeatPercentage = 0;
   bool onBegin = true;
-  /**
-   * Safeguard against executing onBegin action multiple times when execution
-   * threshold is surpassed multiple times
-   */
-  bool onBeginExecuted = false;
 };
 
 

--- a/src/actions/run-command.cpp
+++ b/src/actions/run-command.cpp
@@ -19,7 +19,7 @@
 
 #include <cstdlib>
 
-void RunCommand::onGestureBegin(const Gesture& /*gesture*/) {
+void RunCommand::executePrelude() {
   if (this->settings.count("command") == 1) {
     this->command = this->settings.at("command");
   }
@@ -27,42 +27,14 @@ void RunCommand::onGestureBegin(const Gesture& /*gesture*/) {
   if (this->settings.count("decreaseCommand") == 1) {
     this->decreaseCommand = this->settings.at("decreaseCommand");
   }
-
-  if (this->settings.count("repeat") == 1) {
-    this->repeat = (this->settings.at("repeat") == "true");
-  }
-
-  if (this->settings.count("on") == 1) {
-    this->onBegin = (this->settings.at("on") == "begin");
-  }
-
-  if (!this->repeat && this->onBegin) {
-    RunCommand::runCommand(this->command);
-  }
 }
 
-void RunCommand::onGestureUpdate(const Gesture& gesture) {
-  if (this->repeat) {
-    constexpr int step = 10;
-    bool increased = (gesture.percentage() >= (this->repeatPercentage + step));
-    bool decreased = (gesture.percentage() <= (this->repeatPercentage - step));
-
-    if (increased) {
-      RunCommand::runCommand(this->command);
-      this->repeatPercentage += step;
-    }
-
-    if (decreased) {
-      RunCommand::runCommand(this->decreaseCommand);
-      this->repeatPercentage -= step;
-    }
-  }
+void RunCommand::executeAction(const Gesture& /*gesture*/) {
+  RunCommand::runCommand(this->command);
 }
 
-void RunCommand::onGestureEnd(const Gesture& /*gesture*/) {
-  if (!this->repeat && !this->onBegin) {
-    RunCommand::runCommand(this->command);
-  }
+void RunCommand::executeReverse(const Gesture& /*gesture*/) {
+  RunCommand::runCommand(this->decreaseCommand);
 }
 
 bool RunCommand::runCommand(const std::string& command) {

--- a/src/actions/run-command.h
+++ b/src/actions/run-command.h
@@ -29,9 +29,9 @@ class RunCommand : public RepeatedAction {
  public:
   using RepeatedAction::RepeatedAction;
   bool runOnSystemWindows() override { return true; }
-  virtual void executePrelude() override;
-  virtual void executeAction(const Gesture &gesture) override;
-  virtual void executeReverse(const Gesture &gesture) override;
+  void executePrelude() override;
+  void executeAction(const Gesture &gesture) override;
+  void executeReverse(const Gesture &gesture) override;
 
  private:
   std::string command;

--- a/src/actions/run-command.h
+++ b/src/actions/run-command.h
@@ -20,25 +20,22 @@
 
 #include <string>
 
-#include "actions/action.h"
+#include "actions/repeated-action.h"
 
 /**
  * Action to emulate a shortcut.
  */
-class RunCommand : public Action {
+class RunCommand : public RepeatedAction {
  public:
-  using Action::Action;
+  using RepeatedAction::RepeatedAction;
   bool runOnSystemWindows() override { return true; }
-  void onGestureBegin(const Gesture &gesture) override;
-  void onGestureUpdate(const Gesture &gesture) override;
-  void onGestureEnd(const Gesture &gesture) override;
+  virtual void executePrelude() override;
+  virtual void executeAction(const Gesture &gesture) override;
+  virtual void executeReverse(const Gesture &gesture) override;
 
  private:
   std::string command;
   std::string decreaseCommand;
-  bool repeat = false;
-  int repeatPercentage = 0;
-  bool onBegin = true;
 
   static bool runCommand(const std::string &command);
 };

--- a/src/actions/send-keys.h
+++ b/src/actions/send-keys.h
@@ -21,26 +21,24 @@
 #include <string>
 #include <vector>
 
-#include "actions/action.h"
+#include "actions/repeated-action.h"
 
 /**
  * Action to emulate a shortcut.
  */
-class SendKeys : public Action {
+class SendKeys : public RepeatedAction {
  public:
-  using Action::Action;
+  using RepeatedAction::RepeatedAction;
   bool runOnSystemWindows() override { return true; }
-  void onGestureBegin(const Gesture &gesture) override;
-  void onGestureUpdate(const Gesture &gesture) override;
-  void onGestureEnd(const Gesture &gesture) override;
+  virtual void executePrelude() override;
+  virtual void executePostlude() override;
+  virtual void executeAction(const Gesture &gesture) override;
+  virtual void executeReverse(const Gesture &gesture) override;
 
  private:
   std::vector<std::string> modifiers;
   std::vector<std::string> keys;
   std::vector<std::string> decreaseKeys;
-  bool repeat = false;
-  int repeatPercentage = 0;
-  bool onBegin = true;
 };
 
 #endif  // ACTIONS_SEND_KEYS_H_

--- a/src/actions/send-keys.h
+++ b/src/actions/send-keys.h
@@ -30,10 +30,10 @@ class SendKeys : public RepeatedAction {
  public:
   using RepeatedAction::RepeatedAction;
   bool runOnSystemWindows() override { return true; }
-  virtual void executePrelude() override;
-  virtual void executePostlude() override;
-  virtual void executeAction(const Gesture &gesture) override;
-  virtual void executeReverse(const Gesture &gesture) override;
+  void executePrelude() override;
+  void executePostlude() override;
+  void executeAction(const Gesture &gesture) override;
+  void executeReverse(const Gesture &gesture) override;
 
  private:
   std::vector<std::string> modifiers;


### PR DESCRIPTION
Partly fixes #419 

1. Notice that `send-keys` and `run-command` are very similar, abstract that into `repeated-action`
2. Make `repeated-action` respect animation threshold (even though there are no animations there)
3. Notice that `repeated-action` and `animated-action` use threshold in the same way, abstract that into `action`

Now the only action that doesn't respect threshold is `mouse-click`, but it's pretty different in usage from the others, so I'm not sure. It's used for tablets, right? What completion percentages are emitted there for gestures?