### PR TITLE
Add WM_NAME, WM_CLASS properties to cairo surface

### DIFF
--- a/src/window-system/x11-cairo-surface.cpp
+++ b/src/window-system/x11-cairo-surface.cpp
@@ -58,12 +58,13 @@ X11CairoSurface::X11CairoSurface(Display *display) : display(display) {
   XMapWindow(display, this->window);
 
   // Add WM_NAME and WM_CLASS properties to the window
-  std::string name("touchégg");
-  XStoreName(display, this->window, &name[0]);
+  std::string name{"touchegg"};
+  XStoreName(display, this->window, name.c_str());
   XClassHint *classHint = XAllocClassHint();
-  classHint->res_name = &name[0];
-  classHint->res_class = &name[0];
+  classHint->res_name = name.data();
+  classHint->res_class = name.data();
   XSetClassHint(display, this->window, classHint);
+  XFree(classHint);
 
   // Create the window cairo surface and context
   this->windowSurface = cairo_xlib_surface_create(this->display, this->window,

--- a/src/window-system/x11-cairo-surface.cpp
+++ b/src/window-system/x11-cairo-surface.cpp
@@ -57,6 +57,14 @@ X11CairoSurface::X11CairoSurface(Display *display) : display(display) {
       CWColormap | CWBorderPixel | CWBackPixel | CWOverrideRedirect, &attr);
   XMapWindow(display, this->window);
 
+  // Add WM_NAME and WM_CLASS properties to the window
+  std::string name("touchégg");
+  XStoreName(display, this->window, &name[0]);
+  XClassHint *classHint = XAllocClassHint();
+  classHint->res_name = &name[0];
+  classHint->res_class = &name[0];
+  XSetClassHint(display, this->window, classHint);
+
   // Create the window cairo surface and context
   this->windowSurface = cairo_xlib_surface_create(this->display, this->window,
                                                   vInfo.visual, width, height);


### PR DESCRIPTION
Hi! So I have background-blur enabled by default on all my windows (I use [picom](https://github.com/yshui/picom)) and when an animation ran it blurred my whole screen.

I couldn't find a way to select the window that displays the animations, so I added the `WM_NAME` (line 62) and `WM_CLASS` (line 66) properties.

I don't know if there is a better way to cast a `std::string` to `char*`, and I'm not sure if you want the property to not have the accent mark (I think it should be fine because [`WM_NAME` and `WM_CLASS` are strings encoded with ISO Latin-1 characters](https://tronche.com/gui/x/icccm/sec-2.html#s-2.7.1) and [é is included in that set](https://en.wikipedia.org/wiki/ISO/IEC_8859-1)).