### PR TITLE
Fix crash when sending an event to closed socket

### DIFF
--- a/src/daemon/daemon-server.cpp
+++ b/src/daemon/daemon-server.cpp
@@ -101,7 +101,7 @@ void DaemonServer::send(GestureEventType eventType,
   std::vector<int> disconnectedClients{};
 
   for (auto client : this->clients) {
-    int written = write(client, &event, event.eventSize);
+    int written = ::send(client, &event, event.eventSize, MSG_NOSIGNAL);
 
     if (written < 0) {
       std::cout << "Error sending message to client with ID " << client


### PR DESCRIPTION
Hi again! I don't know if this would be better as an issue, but here's my bug report: 

### Describe the bug

1. Run both daemon and client
2. Kill the client
3. Make a gesture

### Expected behaviour

I think it should print the string on line https://github.com/JoseExposito/touchegg/blob/53aa6e8ddf2300912e202161b1b5844f743d199b/src/daemon/daemon-server.cpp#L107

### Actual behaviour

The daemon crashes with exit code 141 (SIGPIPE) because https://github.com/JoseExposito/touchegg/blob/53aa6e8ddf2300912e202161b1b5844f743d199b/src/daemon/daemon-server.cpp#L104 tries to write to a closed socket

### Your environment

 * Version of Touchégg: 2.0.5
 * Operating System: Arch Linux
 * Desktop Environment: i3

My solution was changing the `write` call to a `send` with option `MSG_NOSIGNAL` so that it doesn't crash when writing to a closed socket and instead returns an error. I basically did this https://stackoverflow.com/a/1705705

Gracias por la ayuda y por la aplicación!