### PR TITLE
Add fullscreen option to MAXIMIZE_RESTORE_WINDOW

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Options:
 
 | Option | Value | Description |
 | - | - | - |
+| fullscreen | `true`/`false` | Set it to `true` to display the window in fullscreen mode instead of maximizing it. `false` otherwise. |
 | animate | `true`/`false` | Set it to `true` to display the animation. `false` otherwise. |
 | color | Hex color | Color of the animation. For example: `909090` |
 | borderColor | Hex color | Border color of the animation. For example: `#FFFFFF` |

--- a/src/actions/maximize-restore-window.cpp
+++ b/src/actions/maximize-restore-window.cpp
@@ -23,8 +23,15 @@
 #include "animations/restore-window-animation.h"
 
 void MaximizeRestoreWindow::onGestureBegin(const Gesture& /*gesture*/) {
+  if (this->settings.count("fullscreen") == 1) {
+    this->fullscreen = this->settings.at("fullscreen") == "true";
+  }
+
   if (this->animate) {
-    if (this->windowSystem.isWindowMaximized(this->window)) {
+    bool restoreWindowAnimation =
+        this->fullscreen ? this->windowSystem.isWindowFullscreen(this->window)
+                         : this->windowSystem.isWindowMaximized(this->window);
+    if (restoreWindowAnimation) {
       this->animation = std::make_unique<RestoreWindowAnimation>(
           this->windowSystem, this->window, this->color, this->borderColor);
     } else {
@@ -35,5 +42,9 @@ void MaximizeRestoreWindow::onGestureBegin(const Gesture& /*gesture*/) {
 }
 
 void MaximizeRestoreWindow::executeAction(const Gesture& /*gesture*/) {
-  this->windowSystem.maximizeOrRestoreWindow(this->window);
+  if (this->fullscreen) {
+    this->windowSystem.toggleFullscreenWindow(this->window);
+  } else {
+    this->windowSystem.maximizeOrRestoreWindow(this->window);
+  }
 }

--- a/src/actions/maximize-restore-window.h
+++ b/src/actions/maximize-restore-window.h
@@ -30,6 +30,9 @@ class MaximizeRestoreWindow : public AnimatedAction {
   bool runOnSystemWindows() override { return false; }
   void onGestureBegin(const Gesture &gesture) override;
   void executeAction(const Gesture &gesture) override;
+
+ private:
+  bool fullscreen = false;
 };
 
 #endif  // ACTIONS_MAXIMIZE_RESTORE_WINDOW_H_

--- a/src/window-system/window-system.h
+++ b/src/window-system/window-system.h
@@ -72,6 +72,11 @@ class WindowSystem {
   virtual bool isWindowMaximized(const WindowT &window) const = 0;
 
   /**
+   * @returns If the window is in fullscreen.
+   */
+  virtual bool isWindowFullscreen(const WindowT &window) const = 0;
+
+  /**
    * @returns If the window is a system window, like the desktop window, the
    * dock, a panel, etc
    */
@@ -81,6 +86,12 @@ class WindowSystem {
    * If the window is not maximized, maximize it, otherwise restore its size.
    */
   virtual void maximizeOrRestoreWindow(const WindowT &window) const = 0;
+
+  /**
+   * Fullscreen a window if it isn't using the whole screen, otherwise restore
+   * its size.
+   */
+  virtual void toggleFullscreenWindow(const WindowT &window) const = 0;
 
   /**
    * Minimize a window.

--- a/src/window-system/x11.h
+++ b/src/window-system/x11.h
@@ -52,8 +52,10 @@ class X11 : public WindowSystem {
   std::string getWindowClassName(const WindowT &window) const override;
   Rectangle getWindowSize(const WindowT &window) const override;
   bool isWindowMaximized(const WindowT &window) const override;
+  bool isWindowFullscreen(const WindowT &window) const override;
   bool isSystemWindow(const WindowT &window) const override;
   void maximizeOrRestoreWindow(const WindowT &window) const override;
+  void toggleFullscreenWindow(const WindowT &window) const override;
   void minimizeWindow(const WindowT &window) const override;
   Rectangle minimizeWindowIconSize(const WindowT &window) const override;
   void tileWindow(const WindowT &window, bool toTheLeft) const override;


### PR DESCRIPTION
This PR adds a `fullscreen` option (disabled by default) to the MAXIMIZE_RESTORE_WINDOW action that toggles the `_NET_WM_STATE_FULLSCREEN` atom on windows instead of the `_NET_WM_STATE_MAXIMIZED_VERT` and `_NET_WM_STATE_MAXIMIZED_HORZ`.

I implemented `X11::isWindowFullscreen` based on `X11::isWindowMaximized` but you could probably delete the `bool fullscreen` declaration and make an early return if you find the atom.

It is useful for tiling window managers that don't care about the other atoms, like i3: https://i3wm.org/docs/hacking-howto.html#_net_wm_state