### PR TITLE
Fix Python2 search in CMake code style check

### DIFF
--- a/cmake/check-code-style.cmake
+++ b/cmake/check-code-style.cmake
@@ -24,7 +24,7 @@ else()
 endif()
 
 find_program(PYTHON_EXEC NAMES "python2")
-if(NOT CLANG_TIDY_EXEC)
+if(NOT PYTHON_EXEC)
   message(WARNING "Check for python2: Not found, cpplint.py will not be executed")
 else()
   message(STATUS "Check for python2: Found")


### PR DESCRIPTION
I think you meant to use the `PYTHON_EXEC` variable