### PR TITLE
Add fullscreen action

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,30 @@ Example:
 
 ![Animation](.github/images/MAXIMIZE_RESTORE_WINDOW.gif)
 
+### Fullscreen a window (FULLSCREEN_WINDOW)
+
+Toggles fullscreen mode for the window under the pointer.
+
+Options:
+
+| Option | Value | Description |
+| - | - | - |
+| animate | `true`/`false` | Set it to `true` to display the animation. `false` otherwise. |
+| color | Hex color | Color of the animation. For example: `909090` |
+| borderColor | Hex color | Border color of the animation. For example: `#FFFFFF` |
+
+Example:
+
+```xml
+<gesture type="SWIPE" fingers="3" direction="UP">
+  <action type="FULLSCREEN_WINDOW">
+    <animate>true</animate>
+    <color>3E9FED</color>
+    <borderColor>3E9FED</borderColor>
+  </action>
+</gesture>
+```
+
 ### Minimize a window (MINIMIZE_WINDOW)
 
 Minimize the window under the pointer.

--- a/src/actions/action-factory.cpp
+++ b/src/actions/action-factory.cpp
@@ -22,6 +22,7 @@
 #include "actions/action.h"
 #include "actions/change-desktop.h"
 #include "actions/close-window.h"
+#include "actions/fullscreen-window.h"
 #include "actions/maximize-restore-window.h"
 #include "actions/minimize-window.h"
 #include "actions/mouse-click.h"
@@ -37,6 +38,9 @@ std::unique_ptr<Action> ActionFactory::buildAction(
   switch (type) {
     case ActionType::MAXIMIZE_RESTORE_WINDOW:
       return std::make_unique<MaximizeRestoreWindow>(
+          std::move(settings), windowSystem, window, config);
+    case ActionType::FULLSCREEN_WINDOW:
+      return std::make_unique<FullscreenWindow>(
           std::move(settings), windowSystem, window, config);
     case ActionType::MINIMIZE_WINDOW:
       return std::make_unique<MinimizeWindow>(std::move(settings), windowSystem,

--- a/src/actions/action-factory.cpp
+++ b/src/actions/action-factory.cpp
@@ -40,8 +40,8 @@ std::unique_ptr<Action> ActionFactory::buildAction(
       return std::make_unique<MaximizeRestoreWindow>(
           std::move(settings), windowSystem, window, config);
     case ActionType::FULLSCREEN_WINDOW:
-      return std::make_unique<FullscreenWindow>(
-          std::move(settings), windowSystem, window, config);
+      return std::make_unique<FullscreenWindow>(std::move(settings),
+                                                windowSystem, window, config);
     case ActionType::MINIMIZE_WINDOW:
       return std::make_unique<MinimizeWindow>(std::move(settings), windowSystem,
                                               window, config);

--- a/src/actions/action-type.h
+++ b/src/actions/action-type.h
@@ -23,6 +23,7 @@
 enum class ActionType {
   NOT_SUPPORTED,
   MAXIMIZE_RESTORE_WINDOW,
+  FULLSCREEN_WINDOW,
   MINIMIZE_WINDOW,
   TILE_WINDOW,
   CLOSE_WINDOW,
@@ -39,6 +40,8 @@ inline std::string actionTypeToStr(ActionType actionType) {
   switch (actionType) {
     case ActionType::MAXIMIZE_RESTORE_WINDOW:
       return "MAXIMIZE_RESTORE_WINDOW";
+    case ActionType::FULLSCREEN_WINDOW:
+      return "FULLSCREEN_WINDOW";
     case ActionType::MINIMIZE_WINDOW:
       return "MINIMIZE_WINDOW";
     case ActionType::TILE_WINDOW:
@@ -63,6 +66,9 @@ inline std::string actionTypeToStr(ActionType actionType) {
 inline ActionType actionTypeFromStr(const std::string &str) {
   if (str == "MAXIMIZE_RESTORE_WINDOW") {
     return ActionType::MAXIMIZE_RESTORE_WINDOW;
+  }
+  if (str == "FULLSCREEN_WINDOW") {
+    return ActionType::FULLSCREEN_WINDOW;
   }
   if (str == "MINIMIZE_WINDOW") {
     return ActionType::MINIMIZE_WINDOW;

--- a/src/actions/fullscreen-window.cpp
+++ b/src/actions/fullscreen-window.cpp
@@ -15,7 +15,7 @@
  * You should have received a copy of the  GNU General Public License along with
  * Touchégg. If not, see <http://www.gnu.org/licenses/>.
  */
-#include "fullscreen-window.h"
+#include "actions/fullscreen-window.h"
 
 #include <memory>
 

--- a/src/actions/fullscreen-window.cpp
+++ b/src/actions/fullscreen-window.cpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2011 - 2021 José Expósito <jose.exposito89@gmail.com>
+ *
+ * This file is part of Touchégg.
+ *
+ * Touchégg is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License  as  published by  the  Free Software
+ * Foundation,  either version 3 of the License,  or (at your option)  any later
+ * version.
+ *
+ * Touchégg is distributed in the hope that it will be useful,  but  WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the  GNU General Public License  for more details.
+ *
+ * You should have received a copy of the  GNU General Public License along with
+ * Touchégg. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "fullscreen-window.h"
+
+#include <memory>
+
+#include "animations/maximize-window-animation.h"
+#include "animations/restore-window-animation.h"
+
+void FullscreenWindow::onGestureBegin(const Gesture& /*gesture*/) {
+  if (this->animate) {
+    if (this->windowSystem.isWindowFullscreen(this->window)) {
+      this->animation = std::make_unique<RestoreWindowAnimation>(
+          this->windowSystem, this->window, this->color, this->borderColor);
+    } else {
+      this->animation = std::make_unique<MaximizeWindowAnimation>(
+          this->windowSystem, this->window, this->color, this->borderColor);
+    }
+  }
+}
+
+void FullscreenWindow::executeAction(const Gesture& /*gesture*/) {
+  this->windowSystem.toggleFullscreenWindow(this->window);
+}

--- a/src/actions/fullscreen-window.h
+++ b/src/actions/fullscreen-window.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2011 - 2021 José Expósito <jose.exposito89@gmail.com>
+ *
+ * This file is part of Touchégg.
+ *
+ * Touchégg is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License  as  published by  the  Free Software
+ * Foundation,  either version 3 of the License,  or (at your option)  any later
+ * version.
+ *
+ * Touchégg is distributed in the hope that it will be useful,  but  WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the  GNU General Public License  for more details.
+ *
+ * You should have received a copy of the  GNU General Public License along with
+ * Touchégg. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef ACTIONS_FULLSCREEN_WINDOW_H_
+#define ACTIONS_FULLSCREEN_WINDOW_H_
+
+#include "actions/animated-action.h"
+
+/**
+ * Action to make the window under the pointer use the whole screen.
+ */
+class FullscreenWindow : public AnimatedAction {
+ public:
+  using AnimatedAction::AnimatedAction;
+  bool runOnSystemWindows() override { return false; }
+  void onGestureBegin(const Gesture &gesture) override;
+  void executeAction(const Gesture &gesture) override;
+};
+
+#endif  // ACTIONS_FULLSCREEN_WINDOW_H_

--- a/src/window-system/window-system.h
+++ b/src/window-system/window-system.h
@@ -72,6 +72,11 @@ class WindowSystem {
   virtual bool isWindowMaximized(const WindowT &window) const = 0;
 
   /**
+   * @returns If the window is in fullscreen.
+   */
+  virtual bool isWindowFullscreen(const WindowT &window) const = 0;
+
+  /**
    * @returns If the window is a system window, like the desktop window, the
    * dock, a panel, etc
    */
@@ -81,6 +86,12 @@ class WindowSystem {
    * If the window is not maximized, maximize it, otherwise restore its size.
    */
   virtual void maximizeOrRestoreWindow(const WindowT &window) const = 0;
+
+  /**
+   * Fullscreen a window if it isn't using the whole screen, otherwise restore
+   * its size.
+   */
+  virtual void toggleFullscreenWindow(const WindowT &window) const = 0;
 
   /**
    * Minimize a window.

--- a/src/window-system/x11.h
+++ b/src/window-system/x11.h
@@ -52,8 +52,10 @@ class X11 : public WindowSystem {
   std::string getWindowClassName(const WindowT &window) const override;
   Rectangle getWindowSize(const WindowT &window) const override;
   bool isWindowMaximized(const WindowT &window) const override;
+  bool isWindowFullscreen(const WindowT &window) const override;
   bool isSystemWindow(const WindowT &window) const override;
   void maximizeOrRestoreWindow(const WindowT &window) const override;
+  void toggleFullscreenWindow(const WindowT &window) const override;
   void minimizeWindow(const WindowT &window) const override;
   Rectangle minimizeWindowIconSize(const WindowT &window) const override;
   void tileWindow(const WindowT &window, bool toTheLeft) const override;


### PR DESCRIPTION
This PR adds a fullscreen action named `FULLSCREEN_WINDOW` that toggles the `_NET_WM_STATE_FULLSCREEN` atom on windows instead of the `_NET_WM_STATE_MAXIMIZED_VERT` and `_NET_WM_STATE_MAXIMIZED_HORZ`.

It is useful for tiling window managers that don't care about the other atoms, like i3: https://i3wm.org/docs/hacking-howto.html#_net_wm_state