### PR TITLE
Add CI build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         uses: "actions/upload-artifact@v2"
         with:
           name: "${{ env.GITHUB_REPOSITORY_NAME }}-#${{ env.GITHUB_SHA_SHORT }}-changelog"
-          path: debian/changelog
+          path: ${{ github.workspace }}/debian/changelog
 
   debian:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,75 @@
+name: Build
+
+on: push
+
+jobs:
+  patch-src:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Debian Docker container for changelog patching
+        # '--ignore-branch' for testing on feature branch
+        run: |
+          docker create --name chglog --volume ${{ github.workspace }}:${{ github.workspace }} --workdir ${{ github.workspace }}/ --tty pitop/gbp-dch-gen:latest sleep inf
+          docker start chglog
+          docker exec chglog git config --global user.name "GitHub Build Action"
+          docker exec chglog git config --global user.email "https://github.com/${{ env.GITHUB_REPOSITORY_NAME }}"
+
+      - name: Patch changelog (snapshot)
+        # '--ignore-branch' for testing on feature branch
+        run: |
+          docker exec chglog gbp dch --verbose --auto --git-author --ignore-branch --snapshot
+
+      - name: Show updated changelog
+        run: |
+          cat debian/changelog
+
+      - name: GitHub Environment Variables Action
+        uses: FranzDiebold/github-env-vars-action@v1.2.1
+
+      - name: Upload patched src as artifact
+        uses: "actions/upload-artifact@v2"
+        with:
+          name: "${{ env.GITHUB_REPOSITORY_NAME }}-#${{ env.GITHUB_SHA_SHORT }}-changelog"
+          path: debian/changelog
+
+  debian:
+    runs-on: ubuntu-20.04
+    needs: [ patch-src ]
+    strategy:
+      matrix:
+        target_arch: ["armhf", "arm64"]
+    steps:
+      - name: GitHub Environment Variables Action
+        uses: FranzDiebold/github-env-vars-action@v1.2.1
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download patched changelog
+        uses: "actions/download-artifact@v2"
+        with:
+            name: "${{ env.GITHUB_REPOSITORY_NAME }}-#${{ env.GITHUB_SHA_SHORT }}-changelog"
+            path: "${{ github.workspace }}/${{ env.GITHUB_REPOSITORY_NAME }}/debian/changelog"
+
+      - name: Build Debian package
+        uses: pi-top/action-debian-package@v0.2.0
+        with:
+          source_directory: "./"
+          artifacts_directory: "./artifacts"
+
+          docker_image: "pitop/deb-build:latest"
+          distribution: "buster-backports"
+          target_architecture: ${{ matrix.target_arch }}
+
+          lintian_opts: "--dont-check-part nmu --no-tag-display-limit --display-info --show-overrides"
+          # Package uses latest packaging syntax and Lintian opts/tags
+          dpkg_buildpackage_opts: "--no-sign --no-check-builddeps --post-clean"
+
+      - name: Upload Debian package artifacts
+        uses: "actions/upload-artifact@v2"
+        with:
+          name: "${{ env.GITHUB_REPOSITORY_NAME }}-#${{ env.GITHUB_SHA_SHORT }}-${{matrix.target_arch}}-deb"
+          path: "${{ github.workspace }}/artifacts"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: GitHub Environment Variables Action
+        uses: FranzDiebold/github-env-vars-action@v1.2.1
+
       - name: Set up Debian Docker container for changelog patching
         # '--ignore-branch' for testing on feature branch
         run: |
           docker create --name chglog --volume ${{ github.workspace }}:${{ github.workspace }} --workdir ${{ github.workspace }}/ --tty pitop/gbp-dch-gen:latest sleep inf
           docker start chglog
-          docker exec chglog git config --global user.name "GitHub Build Action"
-          docker exec chglog git config --global user.email "https://github.com/${{ env.GITHUB_REPOSITORY_NAME }}"
+          docker exec chglog git config --global user.name "José Expósito"
+          docker exec chglog git config --global user.email "jose.exposito89@gmail.com"
 
       - name: Patch changelog (snapshot)
         # '--ignore-branch' for testing on feature branch
@@ -25,9 +28,6 @@ jobs:
       - name: Show updated changelog
         run: |
           cat debian/changelog
-
-      - name: GitHub Environment Variables Action
-        uses: FranzDiebold/github-env-vars-action@v1.2.1
 
       - name: Upload patched src as artifact
         uses: "actions/upload-artifact@v2"
@@ -40,8 +40,8 @@ jobs:
     needs: [ patch-src ]
     strategy:
       matrix:
-        # target_arch: ["armhf", "arm64"]
-        target_arch: ["amd64"]  # fast debugging
+        # target_arch: ["amd64", "armhf", "arm64"]
+        target_arch: ["amd64"]
     steps:
       - name: GitHub Environment Variables Action
         uses: FranzDiebold/github-env-vars-action@v1.2.1
@@ -60,7 +60,7 @@ jobs:
             path: "${{ github.workspace }}/debian"
 
       - name: Build Debian package
-        uses: pi-top/action-debian-package@changelog-parse-logging
+        uses: pi-top/action-debian-package@v0.2.1
         with:
           source_directory: "${{ github.workspace }}"
           artifacts_directory: "${{ github.workspace }}/artifacts"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Show updated changelog
         run: |
-          cat debian/changelog
+          cat ${{ github.workspace }}/debian/changelog
 
       - name: Upload patched src as artifact
         uses: "actions/upload-artifact@v2"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Delete unpatched changelog
+        run: |
+          rm ${{ github.workspace }}/debian/changelog
+
       - name: Download patched changelog
         uses: "actions/download-artifact@v2"
         with:
@@ -57,8 +61,8 @@ jobs:
       - name: Build Debian package
         uses: pi-top/action-debian-package@v0.2.0
         with:
-          source_directory: "./"
-          artifacts_directory: "./artifacts"
+          source_directory: "${{ github.workspace }}/"
+          artifacts_directory: "${{ github.workspace }}/artifacts"
 
           docker_image: "pitop/deb-build:latest"
           distribution: "buster-backports"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         uses: "actions/download-artifact@v2"
         with:
             name: "${{ env.GITHUB_REPOSITORY_NAME }}-#${{ env.GITHUB_SHA_SHORT }}-changelog"
-            path: "${{ github.workspace }}/debian/changelog"
+            path: "${{ github.workspace }}/debian"
 
       - name: Build Debian package
         uses: pi-top/action-debian-package@changelog-parse-logging

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         uses: "actions/download-artifact@v2"
         with:
             name: "${{ env.GITHUB_REPOSITORY_NAME }}-#${{ env.GITHUB_SHA_SHORT }}-changelog"
-            path: "${{ github.workspace }}/${{ env.GITHUB_REPOSITORY_NAME }}/debian/changelog"
+            path: "${{ github.workspace }}/debian/changelog"
 
       - name: Build Debian package
         uses: pi-top/action-debian-package@v0.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,8 @@ jobs:
     needs: [ patch-src ]
     strategy:
       matrix:
-        target_arch: ["armhf", "arm64"]
+        # target_arch: ["armhf", "arm64"]
+        target_arch: ["amd64"]  # fast debugging
     steps:
       - name: GitHub Environment Variables Action
         uses: FranzDiebold/github-env-vars-action@v1.2.1
@@ -59,7 +60,7 @@ jobs:
             path: "${{ github.workspace }}/debian/changelog"
 
       - name: Build Debian package
-        uses: pi-top/action-debian-package@v0.2.1
+        uses: pi-top/action-debian-package@changelog-parse-logging
         with:
           source_directory: "${{ github.workspace }}"
           artifacts_directory: "${{ github.workspace }}/artifacts"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,10 +59,10 @@ jobs:
             path: "${{ github.workspace }}/debian/changelog"
 
       - name: Build Debian package
-        uses: pi-top/action-debian-package@v0.2.0
+        uses: pi-top/action-debian-package@v0.2.1
         with:
-          source_directory: "./"
-          artifacts_directory: "./artifacts"
+          source_directory: "${{ github.workspace }}"
+          artifacts_directory: "${{ github.workspace }}/artifacts"
 
           docker_image: "pitop/deb-build:latest"
           distribution: "buster-backports"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,7 @@ jobs:
     needs: [ patch-src ]
     strategy:
       matrix:
-        # target_arch: ["amd64", "armhf", "arm64"]
-        target_arch: ["amd64"]
+        target_arch: ["amd64", "armhf", "arm64"]
     steps:
       - name: GitHub Environment Variables Action
         uses: FranzDiebold/github-env-vars-action@v1.2.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Build Debian package
         uses: pi-top/action-debian-package@v0.2.0
         with:
-          source_directory: "${{ github.workspace }}/"
-          artifacts_directory: "${{ github.workspace }}/artifacts"
+          source_directory: "./"
+          artifacts_directory: "./artifacts"
 
           docker_image: "pitop/deb-build:latest"
           distribution: "buster-backports"


### PR DESCRIPTION
A GitHub Action for building Debian packages.

* Builds a deb package automatically from each commit
* Currently builds for `amd64`, `arm64` and `armhf`, but can be extended

This is not a complete CI workflow, as it handles bumping the changelog for unreleased changes (commits after the last release), and as such does not produce "final" changelogs. It could be extended to produce artifacts for releases, if desired.

Here is how the changelog is currently prepended by the workflow:
```
touchegg (2.0.6~1.gbp1d5dc0) UNRELEASED; urgency=medium

  ** SNAPSHOT build @1d5dc0609f723e72f2b93bc502d5bc677729f02f **

  [ root ]
  * UNRELEASED

 -- José Expósito <jose.exposito89@gmail.com>  Tue, 12 Jan 2021 16:34:36 +0000
```