### PR TITLE
Fix #443 Arch Linux: Intermittent crash freeing Gesture unique_ptr

### DIFF
--- a/src/utils/color.cpp
+++ b/src/utils/color.cpp
@@ -57,9 +57,6 @@ void Color::setFromHexString(const std::string &hexString) {
 void Color::setFromAutoColor(ColorType colorType) {
 #ifdef AUTO_COLORS
   gtk_init_check(nullptr, nullptr);
-  while (gtk_events_pending() != 0) {
-    gtk_main_iteration_do(0);
-  }
 
   GtkWidget *label = gtk_label_new("");
   g_object_ref_sink(label);


### PR DESCRIPTION
Remove gtk_events_pending (deprecated in GTK 4) since a GLib event loop is already used



