### PR TITLE
Improved portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,8 @@ endif()
 # https://cmake.org/cmake/help/v3.7/module/CPackRPM.html
 include(GNUInstallDirs)
 
-set(SHARED_CONFIG_PATH "${CMAKE_INSTALL_FULL_DATAROOTDIR}/touchegg/touchegg.conf")
-target_compile_definitions(touchegg PUBLIC SHARED_CONFIG_PATH=\"${SHARED_CONFIG_PATH}\")
+set(SYSTEM_CONFIG_FILE_PATH "${CMAKE_INSTALL_FULL_DATAROOTDIR}/touchegg/touchegg.conf")
+target_compile_definitions(touchegg PUBLIC SYSTEM_CONFIG_FILE_PATH=\"${SYSTEM_CONFIG_FILE_PATH}\")
 
 # configure systemd service unit to use the right path, e.g. @CMAKE_INSTALL_BINDIR@/touchegg
 configure_file(${PROJECT_SOURCE_DIR}/installation/touchegg.service.in ${PROJECT_SOURCE_DIR}/installation/touchegg.service @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,8 @@ include(GNUInstallDirs)
 set(SHARED_CONFIG_PATH "${CMAKE_INSTALL_FULL_DATAROOTDIR}/touchegg/touchegg.conf")
 target_compile_definitions(touchegg PUBLIC SHARED_CONFIG_PATH=\"${SHARED_CONFIG_PATH}\")
 
-# configure systemd service unit to use the right path, e.g. ${CMAKE_INSTALL_BINDIR}/touchegg
-configure_file(${PROJECT_SOURCE_DIR}/installation/touchegg.service.in ${PROJECT_SOURCE_DIR}/installation/touchegg.service)
+# configure systemd service unit to use the right path, e.g. @CMAKE_INSTALL_BINDIR@/touchegg
+configure_file(${PROJECT_SOURCE_DIR}/installation/touchegg.service.in ${PROJECT_SOURCE_DIR}/installation/touchegg.service @ONLY)
 
 install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.conf DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/touchegg) # /usr/share/touchegg/touchegg.conf
 install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/system)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,10 @@ target_compile_definitions(touchegg PUBLIC SYSTEM_CONFIG_FILE_PATH=\"${SYSTEM_CO
 
 # configure systemd service unit to use the right path, e.g. @CMAKE_INSTALL_BINDIR@/touchegg
 configure_file(${PROJECT_SOURCE_DIR}/installation/touchegg.service.in ${PROJECT_SOURCE_DIR}/installation/touchegg.service @ONLY)
+pkg_get_variable(SYSTEMD_SERVICE_DIR systemd systemdsystemunitdir)
 
 install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.conf DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/touchegg) # /usr/share/touchegg/touchegg.conf
-install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/system)
+install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.service DESTINATION ${SYSTEMD_SERVICE_DIR})
 install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.desktop DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/xdg/autostart)
 install(PROGRAMS ${PROJECT_BINARY_DIR}/touchegg DESTINATION ${CMAKE_INSTALL_BINDIR}) # /usr/bin/touchegg
 
@@ -106,11 +107,17 @@ set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${PROJECT_SOURCE_DIR}/installation/rpm/p
 list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "${CMAKE_INSTALL_PREFIX}")
 list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "${CMAKE_INSTALL_BINDIR}")
 list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "${CMAKE_INSTALL_DATAROOTDIR}")
-list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/lib")
-list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/lib/systemd")
-list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/lib/systemd/system")
 list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/etc")
 list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/etc/xdg")
 list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/etc/xdg/autostart")
+
+# Exclude the systemd service dir (usually /lib/systemd/system). Split the path and exclude each subpath.
+# Equivalent to exclude /lib, /lib/systemd and /lib/systemd/system:
+string(REPLACE "/" ";" SYSTEMD_SERVICE_DIRS ${SYSTEMD_SERVICE_DIR})
+set(EXCLUDE_DIR "")
+foreach(DIR ${SYSTEMD_SERVICE_DIRS})
+  set(EXCLUDE_DIR "${EXCLUDE_DIR}/${DIR}")
+  list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION ${EXCLUDE_DIR})
+endforeach()
 
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,16 @@ endif()
 # https://cmake.org/cmake/help/v3.12/module/CPack.html
 # https://cmake.org/cmake/help/v3.7/module/CPackRPM.html
 include(GNUInstallDirs)
-set(CMAKE_INSTALL_PREFIX "/usr")
+
+set(SHARED_CONFIG_PATH "${CMAKE_INSTALL_FULL_DATAROOTDIR}/touchegg/touchegg.conf")
+target_compile_definitions(touchegg PUBLIC SHARED_CONFIG_PATH=\"${SHARED_CONFIG_PATH}\")
+
+# configure systemd service unit to use the right path, e.g. ${CMAKE_INSTALL_BINDIR}/touchegg
+configure_file(${PROJECT_SOURCE_DIR}/installation/touchegg.service.in ${PROJECT_SOURCE_DIR}/installation/touchegg.service)
+
 install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.conf DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/touchegg) # /usr/share/touchegg/touchegg.conf
-install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.service DESTINATION /lib/systemd/system)
-install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.desktop DESTINATION /etc/xdg/autostart)
+install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/system)
+install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.desktop DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/xdg/autostart)
 install(PROGRAMS ${PROJECT_BINARY_DIR}/touchegg DESTINATION ${CMAKE_INSTALL_BINDIR}) # /usr/bin/touchegg
 
 set(CPACK_PACKAGE_NAME touchegg)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ pkg_get_variable(SYSTEMD_SERVICE_DIR systemd systemdsystemunitdir)
 
 install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.conf DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/touchegg) # /usr/share/touchegg/touchegg.conf
 install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.service DESTINATION ${SYSTEMD_SERVICE_DIR})
-install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.desktop DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/xdg/autostart)
+install(FILES ${PROJECT_SOURCE_DIR}/installation/touchegg.desktop DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/xdg/autostart)
 install(PROGRAMS ${PROJECT_BINARY_DIR}/touchegg DESTINATION ${CMAKE_INSTALL_BINDIR}) # /usr/bin/touchegg
 
 set(CPACK_PACKAGE_NAME touchegg)

--- a/installation/README.md
+++ b/installation/README.md
@@ -10,10 +10,12 @@ This file contains a combination of meta information resources and a shortcut to
 
 This file is installed into the system-wide XDG Autostart directory (`/etc/xdg/autostart`), which allows autostarting ordinary desktop entries on desktop environment startup.
 
-## touchegg.service - _Touchégg systemd service_
+## touchegg.service.in - _Touchégg systemd service_
 
 This service runs Touchégg in daemon mode (`touchegg --daemon`) as part of the "input" group.
 The daemon will open a Unix domain socket so any service (usually `touchegg --client`) can have access to libinput's multi-touch gestures.
+
+CMake configures the path for ExecStart and saves the result in `touchegg.service`.
 
 ### Learn more about systemd
 https://wiki.archlinux.org/index.php/Systemd#Basic_systemctl_usage

--- a/installation/touchegg.service.in
+++ b/installation/touchegg.service.in
@@ -5,7 +5,7 @@ Documentation=https://github.com/JoseExposito/touchegg/tree/master/installation#
 [Service]
 Type=simple
 Group=input
-ExecStart=${CMAKE_INSTALL_BINDIR}/touchegg --daemon
+ExecStart=@CMAKE_INSTALL_BINDIR@/touchegg --daemon
 Restart=on-failure
 RestartSec=5s
 

--- a/installation/touchegg.service.in
+++ b/installation/touchegg.service.in
@@ -5,7 +5,7 @@ Documentation=https://github.com/JoseExposito/touchegg/tree/master/installation#
 [Service]
 Type=simple
 Group=input
-ExecStart=/usr/bin/touchegg --daemon
+ExecStart=${CMAKE_INSTALL_BINDIR}/touchegg --daemon
 Restart=on-failure
 RestartSec=5s
 

--- a/installation/touchegg.service.in
+++ b/installation/touchegg.service.in
@@ -5,7 +5,7 @@ Documentation=https://github.com/JoseExposito/touchegg/tree/master/installation#
 [Service]
 Type=simple
 Group=input
-ExecStart=@CMAKE_INSTALL_BINDIR@/touchegg --daemon
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/touchegg --daemon
 Restart=on-failure
 RestartSec=5s
 

--- a/src/utils/paths.cpp
+++ b/src/utils/paths.cpp
@@ -68,7 +68,7 @@ std::filesystem::path Paths::getUserLockFilePath() {
 }
 
 std::filesystem::path Paths::getSystemConfigFilePath() {
-  return std::filesystem::path{SHARED_CONFIG_PATH};
+  return std::filesystem::path{SYSTEM_CONFIG_FILE_PATH};
 }
 
 void Paths::createUserConfigDir() {

--- a/src/utils/paths.cpp
+++ b/src/utils/paths.cpp
@@ -68,7 +68,7 @@ std::filesystem::path Paths::getUserLockFilePath() {
 }
 
 std::filesystem::path Paths::getSystemConfigFilePath() {
-  return std::filesystem::path{"/usr/share/touchegg/touchegg.conf"};
+  return std::filesystem::path{SHARED_CONFIG_PATH};
 }
 
 void Paths::createUserConfigDir() {


### PR DESCRIPTION
I tried to improve portability by removing hardcoded paths and configure files in CMake where needed.

 This makes it possible to build and use on non-FHS distros such as NixOS (discussion [here](https://discourse.nixos.org/t/creating-a-simple-derivation-for-touchegg-but-the-binary-returns-an-error/11801/8)). 