### PR TITLE
Fix build using musl libc

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ Once the service is enabled, run Touchégg manually by running the command `touc
 
 A version for Arch based distributions without systemd support, like Artix, is also available on [AUR](https://aur.archlinux.org/packages/touchegg-nosystemd/)
 
+## Void Linux
+
+Touchégg is available from the main repository. To use it, you have to enable its service after installing.
+
+```bash
+$ sudo xbps-install touchegg
+$ sudo ln -s /etc/sv/touchegg /var/service
+```
+
 ## GNOME
 
 If you are using the GNOME Desktop Environment it is recommended to also install this extension:

--- a/src/utils/client-lock.cpp
+++ b/src/utils/client-lock.cpp
@@ -17,6 +17,7 @@
  */
 #include "utils/client-lock.h"
 
+#include <fcntl.h>
 #include <sys/file.h>
 #include <unistd.h>
 


### PR DESCRIPTION
While packaging the current version for Void Linux (https://github.com/void-linux/void-packages/pull/31123) I noticed the build failing when compiling against [musl](https://musl.libc.org/). This is fixed by including `fcntl.h` for the definition of `open`.