### PR TITLE
Allow multiple actions per gesture and noExecute for `AnimatedAction`

### DIFF
--- a/src/actions/animated-action.cpp
+++ b/src/actions/animated-action.cpp
@@ -31,6 +31,10 @@ AnimatedAction::AnimatedAction(
     this->animate = this->settings.at("animate") == "true";
   }
 
+  if (this->settings.count("noExecute") == 1) {
+    this->noExecute = this->settings.at("noExecute") == "true";
+  }
+
   if (this->animate) {
     std::string color;
     std::string borderColor;
@@ -68,7 +72,8 @@ void AnimatedAction::onGestureUpdate(const Gesture &gesture) {
 }
 
 void AnimatedAction::onGestureEnd(const Gesture &gesture) {
-  if (!this->animate || gesture.percentage() >= this->threshold) {
+  if (!this->noExecute &&
+      (!this->animate || gesture.percentage() >= this->threshold)) {
     this->executeAction(gesture);
   }
 }

--- a/src/actions/animated-action.h
+++ b/src/actions/animated-action.h
@@ -69,6 +69,11 @@ class AnimatedAction : public Action {
   bool animate = true;
 
   /**
+   * If we should skip the final execution in onGestureEnd
+   */
+  bool noExecute = false;
+
+  /**
    * Animation color.
    */
   Color color;

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -50,7 +50,7 @@ void Config::saveGestureConfig(
     const std::unordered_map<std::string, std::string> &actionSettings) {
   std::string key = Config::getConfigKey(application, gestureType, numFingers,
                                          gestureDirection);
-  this->config[key] = std::make_pair(actionType, actionSettings);
+  this->config[key].emplace_back(actionType, actionSettings);
 }
 
 bool Config::hasGestureConfig(const std::string &application,
@@ -61,7 +61,7 @@ bool Config::hasGestureConfig(const std::string &application,
   return (this->config.count(key) == 1);
 }
 
-std::pair<ActionType, std::unordered_map<std::string, std::string>>
+std::vector<std::pair<ActionType, std::unordered_map<std::string, std::string>>>
 Config::getGestureConfig(const std::string &application,
                          GestureType gestureType, int numFingers,
                          GestureDirection gestureDirection) const {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -19,6 +19,7 @@
 #define CONFIG_CONFIG_H_
 
 #include <string>
+#include <vector>
 #include <unordered_map>
 #include <utility>
 
@@ -77,9 +78,9 @@ class Config {
                         GestureDirection gestureDirection) const;
 
   /**
-   * @returns The action configured for the gesture.
+   * @returns The actions configured for the gesture.
    */
-  std::pair<ActionType, std::unordered_map<std::string, std::string>>
+  std::vector<std::pair<ActionType, std::unordered_map<std::string, std::string>>>
   getGestureConfig(const std::string &application, GestureType gestureType,
                    int numFingers, GestureDirection gestureDirection) const;
 
@@ -98,7 +99,7 @@ class Config {
    */
   std::unordered_map<
       std::string,
-      std::pair<ActionType, std::unordered_map<std::string, std::string>>>
+      std::vector<std::pair<ActionType, std::unordered_map<std::string, std::string>>>>
       config;
 
   /**

--- a/src/config/xml-config-loader.cpp
+++ b/src/config/xml-config-loader.cpp
@@ -102,22 +102,21 @@ void XmlConfigLoader::parseApplicationXmlNodes(const pugi::xml_node &rootNode) {
       const std::string fingers = gestureNode.attribute("fingers").value();
       const std::string direction = gestureNode.attribute("direction").value();
 
-      pugi::xml_node actionNode = gestureNode.child("action");
-      const std::string actionType = actionNode.attribute("type").value();
-
-      std::unordered_map<std::string, std::string> actionSettings;
-      for (pugi::xml_node settingNode : actionNode.children()) {
-        const std::string settingName = settingNode.name();
-        const std::string settingValue = settingNode.child_value();
-        actionSettings[settingName] = settingValue;
-      }
-
-      // Save the gesture config for each application
-      for (const std::string &application : applications) {
-        this->config->saveGestureConfig(
-            trim(application), gestureTypeFromStr(gestureType), fingers,
-            gestureDirectionFromStr(direction), actionTypeFromStr(actionType),
-            actionSettings);
+      for (pugi::xml_node actionNode : gestureNode.children("action")) {
+        const std::string actionType = actionNode.attribute("type").value();
+        std::unordered_map<std::string, std::string> actionSettings;
+        for (pugi::xml_node settingNode : actionNode.children()) {
+          const std::string settingName = settingNode.name();
+          const std::string settingValue = settingNode.child_value();
+          actionSettings[settingName] = settingValue;
+        }
+        // Save the gesture config for each application
+        for (const std::string &application : applications) {
+          this->config->saveGestureConfig(
+              trim(application), gestureTypeFromStr(gestureType), fingers,
+              gestureDirectionFromStr(direction), actionTypeFromStr(actionType),
+              actionSettings);
+        }
       }
     }
   }

--- a/src/gesture-controller/gesture-controller.h
+++ b/src/gesture-controller/gesture-controller.h
@@ -45,9 +45,9 @@ class GestureController : public GestureControllerDelegate {
   const WindowSystem &windowSystem;
 
   /**
-   * The action to perform.
+   * The actions to perform.
    */
-  std::unique_ptr<Action> action = nullptr;
+  std::vector<std::unique_ptr<Action>> actions;
 
   /**
    * The window the action is performed on.
@@ -55,7 +55,7 @@ class GestureController : public GestureControllerDelegate {
   std::unique_ptr<WindowT> window;
 
   /**
-   * A flag indicating if we should run the action.
+   * A flag indicating if we should run the action(s).
    */
   bool executeAction = false;
 
@@ -66,10 +66,10 @@ class GestureController : public GestureControllerDelegate {
   GestureDirection rotatedDirection = GestureDirection::UNKNOWN;
 
   /**
-   * @returns The action associated to a gesture or nullptr.
+   * @returns The actions associated to a gesture or nullptr.
    */
-  std::unique_ptr<Action> getActionForGesture(const Gesture &gesture,
-                                              const WindowT &window) const;
+  std::vector<std::unique_ptr<Action>> getActionsForGesture(
+      const Gesture &gesture, const WindowT &window) const;
 };
 
 #endif  // GESTURE_CONTROLLER_GESTURE_CONTROLLER_H_


### PR DESCRIPTION
Implements #418 (already closed), closes #345. See also #403.

Uses the scheme described in #418 – allowing multiple actions to be defined per gesture. There is no change for the user-facing configuration (so all existing config files remain unchanged), except when they want to actually use this feature. In that case, it is easy for the user to simply add another action, just like they would add it for a gesture.

I'm open to hearing about cases where two actions may conflict. Currently, there is no such check, and any number of actions can be chained together – they will be executed one after the other in the order they were defined.

The fix for #345 is as described in #403. The `noExecute` setting is a flag for any animated action that when set, causes it to only show the animation, and not execute the associated action. This required minimal modifications to the existing code.

Please let me know what changes can be made to make this better.