### PR TITLE
Added bits to make automatic fedora copr builds work

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -49,7 +49,7 @@ Or a rpm package: (from the cloned `touchegg` folder)
 
 ```bash
 $ mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-$ tar -czvf ~/rpmbuild/SOURCES/touchegg.tar.gz -C .. touchegg
+$ tar -czvf ~/rpmbuild/SOURCES/touchegg.tar.gz -C .. touchegg  --transform 's/^touchegg/touchegg-2.0.10/'
 $ rpmbuild -ba rpm/touchegg.spec
 $ sudo dnf install ~/rpmbuild/RPMS/x86_64/touchegg-?.?.?-?.x86_64.rpm
 ```

--- a/HACKING.md
+++ b/HACKING.md
@@ -49,7 +49,7 @@ Or a rpm package: (from the cloned `touchegg` folder)
 
 ```bash
 $ mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-$ tar -czvf ~/rpmbuild/SOURCES/touchegg.tar.gz -C .. touchegg  --transform 's/^touchegg/touchegg-2.0.10/'
+$ tar -czvf ~/rpmbuild/SOURCES/touchegg.tar.gz -C .. touchegg --transform s/^touchegg/touchegg-$(git describe --tags --abbrev=0)/
 $ rpmbuild -ba rpm/touchegg.spec
 $ sudo dnf install ~/rpmbuild/RPMS/x86_64/touchegg-?.?.?-?.x86_64.rpm
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ Run Touchégg manually by running the command `touchegg` or reboot to get starte
 
 ## Red Hat, Fedora and derivatives
 
+On Fedora, it is recommended to use the
+[for now unofficial COPR](https://copr.fedorainfracloud.org/coprs/jborque/touchegg/) to install Touchégg and
+receive updates until José creates his own :-)
+
+```bash
+$ sudo dnf copr enable jborque/touchegg
+$ sudo dnf install touchegg
+```
+
+On other RPM based operating systems,
 [Download](https://github.com/JoseExposito/touchegg/releases) the `.rpm` package and install it.
 Double click on the package may work, otherwise install it from the terminal:
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Run Touchégg manually by running the command `touchegg` or reboot to get starte
 
 ## Red Hat, Fedora and derivatives
 
-On Fedora, it is recommended to use the
+On Fedora, openSUSE and CentOS (EPEL) it is recommended to use the
 [official COPR](https://copr.fedorainfracloud.org/coprs/jose_exposito/touchegg/) to install Touchégg and
 receive updates.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ sudo dnf install touchegg
 ```
 
 On other RPM based operating systems,
-[Download](https://github.com/JoseExposito/touchegg/releases) the `.rpm` package and install it.
+[download](https://github.com/JoseExposito/touchegg/releases) the `.rpm` package and install it.
 Double click on the package may work, otherwise install it from the terminal:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ Run Touchégg manually by running the command `touchegg` or reboot to get starte
 ## Red Hat, Fedora and derivatives
 
 On Fedora, it is recommended to use the
-[for now unofficial COPR](https://copr.fedorainfracloud.org/coprs/jborque/touchegg/) to install Touchégg and
-receive updates until José creates his own :-)
+[official COPR](https://copr.fedorainfracloud.org/coprs/jose_exposito/touchegg/) to install Touchégg and
+receive updates.
 
 ```bash
-$ sudo dnf copr enable jborque/touchegg
+$ sudo dnf copr enable jose_exposito/touchegg
 $ sudo dnf install touchegg
 ```
 

--- a/rpm/touchegg.spec
+++ b/rpm/touchegg.spec
@@ -8,6 +8,11 @@ Group:          Applications/Productivity
 Vendor:         José Expósito <jose.exposito89@gmail.com>
 Packager:       José Expósito <jose.exposito89@gmail.com>
 
+BuildRequires: git gcc gcc-c++ gdb cmake rpm-build
+BuildRequires: libudev-devel libinput-devel pugixml-devel cairo-devel
+BuildRequires: libX11-devel libXtst-devel libXrandr-devel libXi-devel
+BuildRequires: glib2-devel gtk3-devel
+
 Autoreq:        1
 Prefix:         %{_prefix}
 Source0:        touchegg.tar.gz
@@ -18,7 +23,7 @@ For example, you can swipe up with 3 fingers to maximize a window or swipe left 
 
 
 %prep
-%setup -n touchegg
+%setup
 
 
 %build


### PR DESCRIPTION
With these small changes you can have your own copr automatic build and repository for fedora like this one https://copr.fedorainfracloud.org/coprs/jborque/touchegg/

