### PR TITLE
Touch update delta on start

### DIFF
--- a/src/gesture-gatherer/libinput-device-handler.cpp
+++ b/src/gesture-gatherer/libinput-device-handler.cpp
@@ -138,10 +138,10 @@ double LininputDeviceHandler::mmToDpi(double mm) {
 
 void LininputDeviceHandler::calculateTouchscreenThreshold(
     double widthMm, double heightMm, LibinputDeviceInfo *outInfo) {
-  // start_threshold -> 5% of the width/height
-  // finish_threshold -> 25% of the width/height
-  constexpr int START_PERCENTAGE = 5;
-  constexpr int FINISH_PERCENTAGE = 25;
+  // start_threshold -> 2% of the width/height
+  // finish_threshold -> 16% of the width/height
+  constexpr int START_PERCENTAGE = 2;
+  constexpr int FINISH_PERCENTAGE = 16;
 
   double minSize = std::min(widthMm, heightMm);
   outInfo->startThreshold = ((minSize * START_PERCENTAGE) / 100);

--- a/src/gesture-gatherer/libinput-touch-handler.cpp
+++ b/src/gesture-gatherer/libinput-touch-handler.cpp
@@ -124,19 +124,16 @@ void LibinputTouchHandler::handleTouchMotion(struct libinput_event *event) {
       this->state.startFingers = this->state.currentFingers;
       this->state.startTimestamp = LininputHandler::getTimestamp();
       this->state.type = this->getGestureType();
+      this->state.direction =
+          (this->state.type == GestureType::SWIPE)
+              ? LininputHandler::calculateSwipeDirection(deltaX, deltaY)
+              : this->calculatePinchDirection();
 
+      // Once the direction is calculated, save the currentX/Y as startX/Y so
+      // the startThreshold is not included in the percentage calculations
       double percentage = 0;
-      if (this->state.type == GestureType::SWIPE) {
-        this->state.direction =
-            LininputHandler::calculateSwipeDirection(deltaX, deltaY);
-        percentage = LininputHandler::calculateSwipeAnimationPercentage(
-            info, this->state.direction, deltaX, deltaY);
-      } else {
-        this->state.direction = this->calculatePinchDirection();
-        double pinchDelta = this->getPinchDelta();
-        percentage = LininputHandler::calculatePinchAnimationPercentage(
-            this->state.direction, pinchDelta);
-      }
+      this->state.startX = this->state.currentX;
+      this->state.startY = this->state.currentY;
 
       auto gesture = std::make_unique<Gesture>(
           this->state.type, this->state.direction, percentage,


### PR DESCRIPTION
Once the gesture starts update the value of `startX/Y` with `currentX/Y` to avoid including the `startThreshold` in the percentage calculations.
