### PR TITLE
Use XRRGetScreenResourcesCurrent for performance

### DIFF
--- a/src/window-system/x11.cpp
+++ b/src/window-system/x11.cpp
@@ -492,7 +492,7 @@ Rectangle X11::getDesktopWorkarea() const {
   Rectangle screen;
   int currentCrtc = 0;
   XRRScreenResources *resources =
-      XRRGetScreenResources(this->display, rootWindow);
+      XRRGetScreenResourcesCurrent(this->display, rootWindow);
 
   while (!screenFound && currentCrtc < resources->ncrtc) {
     XRRCrtcInfo *crtc =
@@ -807,7 +807,7 @@ GestureDirection X11::calculateRotation(GestureType gestureType,
   Rotation rotation = 0;
   int currentCrtc = 0;
   XRRScreenResources *resources =
-      XRRGetScreenResources(this->display, rootWindow);
+      XRRGetScreenResourcesCurrent(this->display, rootWindow);
 
   while (!screenFound && currentCrtc < resources->ncrtc) {
     XRRCrtcInfo *crtc =


### PR DESCRIPTION
Hi I tried this project today but had issues with some laggy behavior. 
I figured out that XRRGetScreenResources was cause of the lags, and also found that XRRGetScreenResourcesCurrent is much faster and should be sufficient for this case.