### PR TITLE
Config: remove two finger pinch for firefox

### DIFF
--- a/installation/touchegg.conf
+++ b/installation/touchegg.conf
@@ -133,7 +133,7 @@
     Configuration for specific applications.
   -->
 
-  <application name="Google-chrome,Chromium-browser,Firefox">
+  <application name="Google-chrome,Chromium-browser">
     <gesture type="PINCH" fingers="2" direction="IN">
       <action type="SEND_KEYS">
         <repeat>true</repeat>


### PR DESCRIPTION
As of recently firefox natively supports smooth two finger pinch to zoom gestures on X11 when using the environment variable `MOZ_USE_XINPUT2=1`. Currently touchegg intercepts pinch gestures for firefox by default, resulting in choppy zooming instead. 

To make use of firefox's native gesture support, this PR removes firefox two finger pinch handling from `touchegg.conf`.