### PR TITLE
Do not use abstract socket on FreeBSD

### DIFF
--- a/src/daemon/dbus.h
+++ b/src/daemon/dbus.h
@@ -18,7 +18,11 @@
 #ifndef DAEMON_DBUS_H_
 #define DAEMON_DBUS_H_
 
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+constexpr auto DBUS_ADDRESS = "unix:path=/tmp/touchegg#0";
+#else
 constexpr auto DBUS_ADDRESS = "unix:abstract=touchegg";
+#endif
 
 constexpr auto DBUS_OBJECT_PATH = "/io/github/joseexposito/Touchegg";
 


### PR DESCRIPTION
FreeBSD does not support abstract Unix sockets, causing the app to crash with error "Error creating D-Bus server: Abstract namespace not supported".

As pointed out by @yurivict, the FreeBSD port of Touchégg patches "src/daemon/dbus.h" to fix this issue:
https://cgit.freebsd.org/ports/tree/sysutils/touchegg/files/patch-src_daemon_dbus.h

Apply a similar patch upstream to fix #611.