### PR TITLE
Add <cstdint> header to avoid compilation errors on GCC 13

### DIFF
--- a/src/gesture/gesture.h
+++ b/src/gesture/gesture.h
@@ -18,6 +18,8 @@
 #ifndef GESTURE_GESTURE_H_
 #define GESTURE_GESTURE_H_
 
+#include <cstdint>
+
 #include "gesture/device-type.h"
 #include "gesture/gesture-direction.h"
 #include "gesture/gesture-type.h"


### PR DESCRIPTION
Currently, when compiling with GCC 13, the following error is displayed:

```
In file included from /builddir/build/BUILD/touchegg-2.0.15/src/actions/action.h:26,
                 from /builddir/build/BUILD/touchegg-2.0.15/src/actions/action.cpp:18:
/builddir/build/BUILD/touchegg-2.0.15/src/gesture/gesture.h:32:58: error: 'uint64_t' has not been declared
    32  |          int fingers, DeviceType performedOnDeviceType, uint64_t elapsedTime)
        |                                                         ^~~~~~~~

/builddir/build/BUILD/touchegg-2.0.15/src/gesture/gesture.h:72:3: error: 'uint64_t' does not name a type
    72  |   uint64_t elapsedTime() const { return this->gestureElapsedTime; }
        |   ^~~~~~~~

/builddir/build/BUILD/touchegg-2.0.15/src/gesture/gesture.h:22:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    21  | #include "gesture/device-type.h"
    +++ |+#include <cstdint>
    22  | #include "gesture/gesture-direction.h"

/builddir/build/BUILD/touchegg-2.0.15/src/gesture/gesture.h:88:3: error: 'uint64_t' does not name a type
    88  |   uint64_t gestureElapsedTime = -1;
        |   ^~~~~~~~

/builddir/build/BUILD/touchegg-2.0.15/src/gesture/gesture.h:88:3: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?

/builddir/build/BUILD/touchegg-2.0.15/src/gesture/gesture.h: In constructor 'Gesture::Gesture(GestureType, GestureDirection, double, int, DeviceType, int)':

/builddir/build/BUILD/touchegg-2.0.15/src/gesture/gesture.h:38:9: error: class 'Gesture' does not have any field named 'gestureElapsedTime'
    38  |   gestureElapsedTime(elapsedTime) {}
        |   ^~~~~~~~~~~~~~~~~~
```

I'm the current maintainer of the Fedora package, which is not currently building due to this error [1].

[1] https://koschei.fedoraproject.org/package/touchegg?collection=f38