### PR TITLE
Mention PPA signing key in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,11 @@ $ sudo apt update
 $ sudo apt install touchegg
 ```
 
+Running `add-apt-repository` may fail because of temporary server issues; try again a few times, it should work.
 The PPA is signed with key
-[7EA12677D47B593CE22727D4C0FCE32AF6B96252](https://keyserver.ubuntu.com/pks/lookup?search=7EA12677D47B593CE22727D4C0FCE32AF6B96252&hash=on&exact=on&op=index).
+[7EA12677D47B593CE22727D4C0FCE32AF6B96252](https://keyserver.ubuntu.com/pks/lookup?search=7EA12677D47B593CE22727D4C0FCE32AF6B96252&hash=on&exact=on&op=index)
+in case you want to install it manually.
+
 If PPAs are not available on your operating system,
 [download](https://github.com/JoseExposito/touchegg/releases) the `.deb` package and install it.
 Double click on the package may work, otherwise install it from the terminal:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ $ sudo apt update
 $ sudo apt install touchegg
 ```
 
+The PPA is signed with key
+[7EA12677D47B593CE22727D4C0FCE32AF6B96252](https://keyserver.ubuntu.com/pks/lookup?search=7EA12677D47B593CE22727D4C0FCE32AF6B96252&hash=on&exact=on&op=index).
 If PPAs are not available on your operating system,
 [download](https://github.com/JoseExposito/touchegg/releases) the `.deb` package and install it.
 Double click on the package may work, otherwise install it from the terminal:


### PR DESCRIPTION
- They PPA signing key may not be installed automatically on all systems.
- Installation through `apt` will not work without the signing key.
- Explicitly mentioning the key id aids those who need to retrieve it manually.

Note that I cannot personally vouch for the validity of the key; that is up to the developer/PPA packager. @JoseExposito can you confirm that [7EA12677D47B593CE22727D4C0FCE32AF6B96252](https://keyserver.ubuntu.com/pks/lookup?search=7EA12677D47B593CE22727D4C0FCE32AF6B96252&hash=on&exact=on&op=index) is the correct PPA signing key? (Either stating it explicitly, or implicitly by merging this commit.)

Closes #602, although it was already closed.

Also aids some users in #604, #578, #472, #466, #462, etcetera in case they attempt manual installation of the  PPA signing key. The underlying problem seems to be that the Ubuntu keyserver is unstable, and responds with "Not found" half of the time (test using link above). In most cases it is easier to just repeat `sudo add-apt-repository ppa:touchegg/stable` a few times, until the server responds and the key is downloaded/installed automatically.