### PR TITLE
client: Disable autostart during a Cinnamon session.

### DIFF
--- a/installation/touchegg.desktop
+++ b/installation/touchegg.desktop
@@ -7,3 +7,4 @@ Terminal=false
 Categories=Utility;
 NoDisplay=true
 StartupNotify=true
+NotShowIn=X-Cinnamon


### PR DESCRIPTION
Cinnamon acts as a client, with more or less the same capabilities, so avoid interference between the two.