### PR TITLE
Allow to execute actions on gesture begin and end

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,8 @@ Options:
 | button | `1`/`2`/`3`/`8`/`9` | Left click (1), middle click (2), right click (3), back button (8) or forward button (9) |
 | on | `begin`/`end`/`begin-and-end` | If the mouse click should be executed on the beginning and/or on the end of the gesture. |
 
+When the `begin-and-end` option is used, the mouse button is down when the gesture begins and up when the gesture ends.
+
 Example:
 
 ```xml

--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ Example 1:
 <gesture type="SWIPE" fingers="4" direction="DOWN">
   <action type="RUN_COMMAND">
     <repeat>false</repeat>
-    <command>notify-send 'Hello World' "Swipe down, DEVICE_TYPE=$TOUCHEGG_DEVICE_TYPE"</command>
+    <command>notify-send 'Hello World' "Swipe down, DEVICE_TYPE=$TOUCHEGG_DEVICE_TYPE TOUCHEGG_GESTURE_ON=$TOUCHEGG_GESTURE_ON"</command>
     <on>begin</on>
   </action>
 </gesture>

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ Options:
 | repeat | `true`/`false` | Whether to execute the keyboard shortcut multiple times (default: `false`). This is useful to perform actions like pinch to zoom. |
 | modifiers | Keysym | Typical values are: `Shift_L`, `Control_L`, `Alt_L`, `Alt_R`, `Meta_L`, `Super_L`, `Hyper_L`. You can use multiple keysyms: `Control_L+Alt_L`.See "Keysyms" below for more information. |
 | keys | Keysym | Shortcut keys. You can use multiple keysyms: `A+B+C`. See "Keysyms" below for more information. |
-| on | `begin`/`end` | Only used when `repeat` is `false`. Whether to execute the shortcut at the beginning or at the end of the gesture. |
+| on | `begin`/`end`/`begin-and-end` | Only used when `repeat` is `false`. Whether to execute the shortcut at the beginning and/or at the end of the gesture. |
 | decreaseKeys | Keysym | Only used when `repeat` is `true`. Keys to press when you change the gesture direction to the opposite. You can use multiple keysyms: `A+B+C`. This is useful to perform actions like pinch to zoom, check `Example 2` below. |
 | times | 2...15 | Only used when `repeat` is `true`. Number of times to repeat the action. |
 | animate | `true`/`false` | Set it to `true` to display the animation set in `animation`. `false` otherwise. |
@@ -640,7 +640,7 @@ Options:
 | - | - | - |
 | repeat | `true`/`false` | `true` if the command should be executed multiple times. `false` otherwise. |
 | command | Command | The command to execute. |
-| on | `begin`/`end` | Only used when `repeat` is `false`. If the command should be executed on the beginning or on the end of the gesture. |
+| on | `begin`/`end`/`begin-and-end` | Only used when `repeat` is `false`. If the command should be executed and/on the beginning or on the end of the gesture. |
 | decreaseCommand | Command | Only used when `repeat` is `true`. Command to run when you change the gesture direction to the opposite. Check `Example 2` below. |
 | times | 2...15 | Only used when `repeat` is `true`. Number of times to repeat the action. |
 | animate | `true`/`false` | Set it to `true` to display the animation set in `animation`. `false` otherwise. |
@@ -681,7 +681,7 @@ Options:
 | Option | Value | Description |
 | - | - | - |
 | button | `1`/`2`/`3`/`8`/`9` | Left click (1), middle click (2), right click (3), back button (8) or forward button (9) |
-| on | `begin`/`end` | If the command should be executed on the beginning or on the end of the gesture. |
+| on | `begin`/`end`/`begin-and-end` | If the mouse click should be executed on the beginning and/or on the end of the gesture. |
 
 Example:
 

--- a/src/actions/execute-action-on.h
+++ b/src/actions/execute-action-on.h
@@ -24,6 +24,7 @@ enum class ExecuteActionOn {
   NOT_SUPPORTED,
   BEGIN,
   END,
+  BEGIN_AND_END,
   // Adding a new value? Don't forget to add it in executeActionOnFromStr and
   // shouldExecuteAction
 };
@@ -35,6 +36,9 @@ inline ExecuteActionOn executeActionOnFromStr(const std::string &str) {
   if (str == "end") {
     return ExecuteActionOn::END;
   }
+  if (str == "begin-and-end") {
+    return ExecuteActionOn::BEGIN_AND_END;
+  }
   return ExecuteActionOn::NOT_SUPPORTED;
 }
 
@@ -44,6 +48,8 @@ inline bool shouldExecuteAction(ExecuteActionOn phase, ExecuteActionOn config) {
       return phase == ExecuteActionOn::BEGIN;
     case ExecuteActionOn::END:
       return phase == ExecuteActionOn::END;
+    case ExecuteActionOn::BEGIN_AND_END:
+      return true;
     default:
       return false;
   }

--- a/src/actions/execute-action-on.h
+++ b/src/actions/execute-action-on.h
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2011 - 2024 José Expósito <jose.exposito89@gmail.com>
+ *
+ * This file is part of Touchégg.
+ *
+ * Touchégg is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License  as  published by  the  Free Software
+ * Foundation,  either version 3 of the License,  or (at your option)  any later
+ * version.
+ *
+ * Touchégg is distributed in the hope that it will be useful,  but  WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the  GNU General Public License  for more details.
+ *
+ * You should have received a copy of the  GNU General Public License along with
+ * Touchégg. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef ACTIONS_EXECUTE_ACTION_ON_H_
+#define ACTIONS_EXECUTE_ACTION_ON_H_
+
+#include <string>
+
+enum class ExecuteActionOn {
+  NOT_SUPPORTED,
+  BEGIN,
+  END,
+  // Adding a new value? Don't forget to add it in executeActionOnFromStr and
+  // shouldExecuteAction
+};
+
+inline ExecuteActionOn executeActionOnFromStr(const std::string &str) {
+  if (str == "begin") {
+    return ExecuteActionOn::BEGIN;
+  }
+  if (str == "end") {
+    return ExecuteActionOn::END;
+  }
+  return ExecuteActionOn::NOT_SUPPORTED;
+}
+
+inline bool shouldExecuteAction(ExecuteActionOn phase, ExecuteActionOn config) {
+  switch (config) {
+    case ExecuteActionOn::BEGIN:
+      return phase == ExecuteActionOn::BEGIN;
+    case ExecuteActionOn::END:
+      return phase == ExecuteActionOn::END;
+    default:
+      return false;
+  }
+}
+
+#endif  // ACTIONS_EXECUTE_ACTION_ON_H_

--- a/src/actions/mouse-click.cpp
+++ b/src/actions/mouse-click.cpp
@@ -27,7 +27,8 @@ void MouseClick::onGestureBegin(const Gesture& /*gesture*/) {
   }
 
   if (shouldExecuteAction(ExecuteActionOn::BEGIN, this->executeActionOn)) {
-    this->windowSystem.sendMouseClick(this->button);
+    this->windowSystem.sendMouseDown(this->button);
+    this->windowSystem.sendMouseUp(this->button);
   }
 }
 
@@ -35,6 +36,7 @@ void MouseClick::onGestureUpdate(const Gesture& /*gesture*/) {}
 
 void MouseClick::onGestureEnd(const Gesture& /*gesture*/) {
   if (shouldExecuteAction(ExecuteActionOn::END, this->executeActionOn)) {
-    this->windowSystem.sendMouseClick(this->button);
+    this->windowSystem.sendMouseDown(this->button);
+    this->windowSystem.sendMouseUp(this->button);
   }
 }

--- a/src/actions/mouse-click.cpp
+++ b/src/actions/mouse-click.cpp
@@ -23,10 +23,10 @@ void MouseClick::onGestureBegin(const Gesture& /*gesture*/) {
   }
 
   if (this->settings.count("on") == 1) {
-    this->onBegin = (this->settings.at("on") == "begin");
+    this->executeActionOn = executeActionOnFromStr(this->settings.at("on"));
   }
 
-  if (this->onBegin) {
+  if (shouldExecuteAction(ExecuteActionOn::BEGIN, this->executeActionOn)) {
     this->windowSystem.sendMouseClick(this->button);
   }
 }
@@ -34,7 +34,7 @@ void MouseClick::onGestureBegin(const Gesture& /*gesture*/) {
 void MouseClick::onGestureUpdate(const Gesture& /*gesture*/) {}
 
 void MouseClick::onGestureEnd(const Gesture& /*gesture*/) {
-  if (!this->onBegin) {
+  if (shouldExecuteAction(ExecuteActionOn::END, this->executeActionOn)) {
     this->windowSystem.sendMouseClick(this->button);
   }
 }

--- a/src/actions/mouse-click.cpp
+++ b/src/actions/mouse-click.cpp
@@ -28,7 +28,10 @@ void MouseClick::onGestureBegin(const Gesture& /*gesture*/) {
 
   if (shouldExecuteAction(ExecuteActionOn::BEGIN, this->executeActionOn)) {
     this->windowSystem.sendMouseDown(this->button);
-    this->windowSystem.sendMouseUp(this->button);
+
+    if (this->executeActionOn != ExecuteActionOn::BEGIN_AND_END) {
+      this->windowSystem.sendMouseUp(this->button);
+    }
   }
 }
 
@@ -36,7 +39,10 @@ void MouseClick::onGestureUpdate(const Gesture& /*gesture*/) {}
 
 void MouseClick::onGestureEnd(const Gesture& /*gesture*/) {
   if (shouldExecuteAction(ExecuteActionOn::END, this->executeActionOn)) {
-    this->windowSystem.sendMouseDown(this->button);
+    if (this->executeActionOn != ExecuteActionOn::BEGIN_AND_END) {
+      this->windowSystem.sendMouseDown(this->button);
+    }
+
     this->windowSystem.sendMouseUp(this->button);
   }
 }

--- a/src/actions/mouse-click.h
+++ b/src/actions/mouse-click.h
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "actions/action.h"
+#include "actions/execute-action-on.h"
 
 /**
  * Action to emulate a shortcut.
@@ -35,7 +36,7 @@ class MouseClick : public Action {
 
  private:
   int button = 1;
-  bool onBegin = true;
+  ExecuteActionOn executeActionOn = ExecuteActionOn::BEGIN;
 };
 
 #endif  // ACTIONS_MOUSE_CLICK_H_

--- a/src/actions/repeated-action.cpp
+++ b/src/actions/repeated-action.cpp
@@ -73,7 +73,10 @@ void RepeatedAction::onGestureUpdate(const Gesture &gesture) {
 void RepeatedAction::onGestureEnd(const Gesture &gesture) {
   if (!this->repeat &&
       shouldExecuteAction(ExecuteActionOn::END, this->executeActionOn)) {
-    if (gesture.percentage() >= this->threshold) {
+    // Do not take into account the threshold is the action is executed on begin
+    // and end. Otherwise, we could miss could execute only the on begin part.
+    if (this->executeActionOn == ExecuteActionOn::BEGIN_AND_END ||
+        gesture.percentage() >= this->threshold) {
       this->executeAction(gesture);
     }
   }

--- a/src/actions/repeated-action.cpp
+++ b/src/actions/repeated-action.cpp
@@ -34,14 +34,15 @@ void RepeatedAction::onGestureBegin(const Gesture &gesture) {
   }
 
   if (this->settings.count("on") == 1) {
-    this->onBegin = (this->settings.at("on") == "begin");
+    this->executeActionOn = executeActionOnFromStr(this->settings.at("on"));
   }
 
   // execute supplied prelude
   this->executePrelude();
 
   // run action on begin
-  if (!this->repeat && this->onBegin) {
+  if (!this->repeat &&
+      shouldExecuteAction(ExecuteActionOn::BEGIN, this->executeActionOn)) {
     this->executeAction(gesture);
   }
 }
@@ -70,7 +71,8 @@ void RepeatedAction::onGestureUpdate(const Gesture &gesture) {
 }
 
 void RepeatedAction::onGestureEnd(const Gesture &gesture) {
-  if (!this->repeat && !this->onBegin) {
+  if (!this->repeat &&
+      shouldExecuteAction(ExecuteActionOn::END, this->executeActionOn)) {
     if (gesture.percentage() >= this->threshold) {
       this->executeAction(gesture);
     }

--- a/src/actions/repeated-action.h
+++ b/src/actions/repeated-action.h
@@ -19,6 +19,7 @@
 #define ACTIONS_REPEATED_ACTION_H_
 
 #include "actions/animated-action.h"
+#include "actions/execute-action-on.h"
 
 class RepeatedAction : public AnimatedAction {
  public:
@@ -84,7 +85,7 @@ class RepeatedAction : public AnimatedAction {
   /**
    * Whether the action should be executed on gesture begin or end.
    */
-  bool onBegin = true;
+  ExecuteActionOn executeActionOn = ExecuteActionOn::BEGIN;
 };
 
 #endif  // ACTIONS_REPEATED_ACTION_H_

--- a/src/actions/run-command.cpp
+++ b/src/actions/run-command.cpp
@@ -22,6 +22,7 @@
 #include "animations/animation-factory.h"
 
 void RunCommand::onGestureBegin(const Gesture &gesture) {
+  setenv("TOUCHEGG_GESTURE_ON", "begin", 1);
   RepeatedAction::onGestureBegin(gesture);
 
   if (!this->animate) {
@@ -36,6 +37,16 @@ void RunCommand::onGestureBegin(const Gesture &gesture) {
         animationType, this->windowSystem, this->window, this->color,
         this->borderColor);
   }
+}
+
+void RunCommand::onGestureUpdate(const Gesture &gesture) {
+  setenv("TOUCHEGG_GESTURE_ON", "update", 1);
+  RepeatedAction::onGestureUpdate(gesture);
+}
+
+void RunCommand::onGestureEnd(const Gesture &gesture) {
+  setenv("TOUCHEGG_GESTURE_ON", "end", 1);
+  RepeatedAction::onGestureEnd(gesture);
 }
 
 void RunCommand::executePrelude() {

--- a/src/actions/run-command.h
+++ b/src/actions/run-command.h
@@ -29,6 +29,8 @@ class RunCommand : public RepeatedAction {
  public:
   using RepeatedAction::RepeatedAction;
   void onGestureBegin(const Gesture &gesture) override;
+  void onGestureUpdate(const Gesture &gesture) override;
+  void onGestureEnd(const Gesture &gesture) override;
   bool runOnSystemWindows() override { return true; }
   void executePrelude() override;
   void executeAction(const Gesture &gesture) override;

--- a/src/window-system/window-system.h
+++ b/src/window-system/window-system.h
@@ -133,13 +133,22 @@ class WindowSystem {
                         bool isPress) const = 0;
 
   /**
-   * Simulates a mouse click.
+   * Simulates a mouse down event.
    * @param button One of this values:
    * 1 – Left button click
    * 2 – Middle button click
    * 3 – Right button click
    */
-  virtual void sendMouseClick(int button) const = 0;
+  virtual void sendMouseDown(int button) const = 0;
+
+  /**
+   * Simulates a mouse up event.
+   * @param button One of this values:
+   * 1 – Left button click
+   * 2 – Middle button click
+   * 3 – Right button click
+   */
+  virtual void sendMouseUp(int button) const = 0;
 
   /**
    * @returns The size of the desktop workarea, ie, the area of the desktop not

--- a/src/window-system/x11.cpp
+++ b/src/window-system/x11.cpp
@@ -466,8 +466,12 @@ void X11::sendKeys(const std::vector<std::string> &keycodes,
   XFlush(this->display);
 }
 
-void X11::sendMouseClick(int button) const {
+void X11::sendMouseDown(int button) const {
   XTestFakeButtonEvent(this->display, button, True, 0);
+  XFlush(this->display);
+}
+
+void X11::sendMouseUp(int button) const {
   XTestFakeButtonEvent(this->display, button, False, 0);
   XFlush(this->display);
 }

--- a/src/window-system/x11.h
+++ b/src/window-system/x11.h
@@ -66,7 +66,8 @@ class X11 : public WindowSystem {
 
   void sendKeys(const std::vector<std::string> &keycodes,
                 bool isPress) const override;
-  void sendMouseClick(int button) const override;
+  void sendMouseDown(int button) const override;
+  void sendMouseUp(int button) const override;
 
   Rectangle getDesktopWorkarea() const override;
   void changeDesktop(ActionDirection direction, bool cyclic) const override;


### PR DESCRIPTION
Until now, it was only possible to execute the `MOUSE_CLICK`, `SEND_KEYS` and `RUN_COMMAND` actions when the gesture started or when the gesture ended.

Include a third option, `<on>begin-and-end</on>` allowing to run the actions both when the gesture starts and ends.

When this new setting is used, `MOUSE_CLICK` starts presses the mouse button when the gesture starts and releases it when the gesture ends.

In the case of `RUN_COMMAND`, a environment variable is set (`TOUCHEGG_GESTURE_ON`) allowing the executed script to take different actions at the beginning and the end of the gesture.

Closes: https://github.com/JoseExposito/touchegg/issues/665