### PR TITLE
Add missing include

### DIFF
--- a/src/animations/animation.h
+++ b/src/animations/animation.h
@@ -20,6 +20,7 @@
 
 #include <cairo.h>
 
+#include <cstdint>
 #include <memory>
 
 #include "window-system/cairo-surface.h"


### PR DESCRIPTION
Include cstdint to fix a compile error on gcc 15.

Closes: https://github.com/JoseExposito/touchegg/issues/679