### PR TITLE
CMake: Set minimum version to 3.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.10.0)
 
 project(touchegg)
 set(MAJOR_VERSION "2")


### PR DESCRIPTION
Compatibility with versions of CMake older than 3.5 has been removed from CMake 4.0.

In addition, compatibility with versions of CMake older than 3.10 has been deprecated in CMake 3.31.

Since we don't rely on old features, just update the minimum required version to 3.10.0.
The target version is available even in Debian Bullseye (oldstable) [1].

[1] https://packages.debian.org/bullseye/cmake

Closes: https://github.com/JoseExposito/touchegg/issues/681