### PR TITLE
clang-format: Avoid breaking change

### DIFF
--- a/src/gesture-gatherer/libinput-gesture-gatherer.cpp
+++ b/src/gesture-gatherer/libinput-gesture-gatherer.cpp
@@ -44,7 +44,9 @@ LibinputGestureGatherer::LibinputGestureGatherer(
       deviceHandler(gestureController, startThreshold, finishThreshold),
       swipeHandler(gestureController),
       pinchHandler(gestureController),
-      touchHandler(gestureController) {
+      touchHandler(gestureController),
+      libinputInterface({LibinputGestureGatherer::openRestricted,
+                         LibinputGestureGatherer::closeRestricted}) {
   this->udevContext = udev_new();
   if (this->udevContext == nullptr) {
     throw std::runtime_error{"Error initialising Touchégg: udev"};

--- a/src/gesture-gatherer/libinput-gesture-gatherer.h
+++ b/src/gesture-gatherer/libinput-gesture-gatherer.h
@@ -73,10 +73,7 @@ class LibinputGestureGatherer : public GestureGatherer {
   /**
    * libinput structure with pointers to the open/close callbacks.
    */
-  struct libinput_interface libinputInterface {
-    LibinputGestureGatherer::openRestricted,
-        LibinputGestureGatherer::closeRestricted
-  };
+  struct libinput_interface libinputInterface;
   static int openRestricted(const char *path, int flags, void *userData);
   static void closeRestricted(int fd, void *userData);
 };


### PR DESCRIPTION
The version of clang-format available on CI requires a format for the initialization of `libinput_interface` that is not compatible with newer versions of clang-format.

Initialize the structure in the constructor to make clang-format happy.

Closes: https://github.com/JoseExposito/touchegg/issues/684